### PR TITLE
[Fix] Multiple YML file corrections.

### DIFF
--- a/game/config/demographics.yml
+++ b/game/config/demographics.yml
@@ -55,19 +55,19 @@ demographics:
       desc: What region does your character call home?
       wiki: theme:regions
       values:
-        Stormgard: The rugged north.
+        Sturmvargd: The rugged north.
         Dran: Harsh, wind-swept steppes.
         Alexandros: The Phoenix Kingdom.
         Empire-Myrddion: The kingdoms of the western Empire.
         Empire-Bludgun: The nation of goblin-kin.
         Empire-Charn: The stygian domain of the Eastern Empire.
         Empire-Desolation: Home of an endless magical storm.
-        Veyshan: Ancient republics of the dune seas.
+        Veyshan: Home of the desert nomads and the city-states of the One-Hundred and Four.
         Dragonier: The nation of the dragon kings.
-        Jade Islands: The home of the Cerenzans.
+        Jade Islands: The remains of a shattered land, populated by the Kaltoi and merchant-circles.
         Greatwoods: The ancient sildanyari kingdoms.
-        Khazad Duin: The great citadel of the khazad and its environs.
-        Am'shere: Jungles and the Makari are your home and its people.
+        Khazad Duin: The great citadel of the khazadi and its environs.
+        Am'shere: The far-away jungles where the makari dwell.
         Vast: Endless, wind-swept plains of ancient magic.
         Rune: The eccentric nation of wizards.
     Faith:

--- a/game/config/pf2e_ancestry.yml
+++ b/game/config/pf2e_ancestry.yml
@@ -9,21 +9,23 @@ pf2e_ancestry:
     - open
     languages:
     - Tradespeak
-    - Gobber
+    - Goblin
     traits:
     - arvek
     - humanoid
     special:
     - darkvision
     heritages:
-    - Aasimar
+    - Aesa
     - Ashen One
     - Changeling
     - Dar
     - Elfbane
+    - Niasa
     - Runtboss
     - Smokeworker
-    - Tiefling
+    - Warmarch
+    - Warrenbred
     feats:
       1:
       - Alchemical Scholar
@@ -31,30 +33,130 @@ pf2e_ancestry:
       - Arvek Weapon Familiarity
       - Leech-Clipper
       - Remorseless Lash
-      - Sneaky
-      - Stone Face
       - Vigorous Health
       5:
       - Agonizing Rebuke
       - Arvek Weapon Discipline
       - Expert Drill Sergeant
       - Formation Training
-      - Recognize Ambush
-      - Runtsage
       9:
       - Pride In Arms
       13:
       - Arvek Weapon Expertise
       - Formation Master
+  Bassin:
+    HP: 6
+    Size: S
+    Speed: 25
+    able_boosts:
+    - open
+    - open
+    languages:
+    - Tradespeak
+    - Bassin
+    traits:
+    - bassin
+    - humanoid
+    special:
+    - keen eyes
+    heritages:
+    - Aesa
+    - Ashen One
+    - Changeling
+    - Dar
+    - Gutsy
+    - Hillock
+    - Jinxed-bassin
+    - Niasa
+    - Nomadic
+    - Twilight
+    - Wildwood
+    feats:
+      1:
+      - Bassin Lore
+      - Bassin Luck
+      - Bassin Weapon Familiarity
+      - Distracting Shadows
+      - Folksy Patter
+      - Prairie Rider
+      - Sure Feet
+      - Titan Slinger
+      - Unfettered Bassin
+      - Watchful Bassin
+      5:
+      - Bassin Weapon Trickster
+      - Cultural Adaptability
+      - Step Lively
+      9:
+      - Dance Underfoot
+      - Guiding Luck
+      - Irrepressible
+      - Unhampered Passage
+      13:
+      - Ceaseless Shadows
+      - Bassin Weapon Expertise
+      - Toppling Dance
       17:
-      - "Azaersi's Roads"
+      - Shadow Self
+  Ciith:
+    HP: 8
+    Size: M
+    Speed: 25
+    abl_boosts:
+    - open
+    - open
+    languages:
+    - Tradespeak
+    - Draconic
+    traits:
+    - ciith
+    - humanoid
+    attack:
+      Claws:
+        damage: d4
+        damage_type: S
+        traits:
+        - agile
+        - finesse
+        - unarmed
+    bonus_feats:
+    - Breath Control
+    heritages:
+    - Aesa
+    - Ashen One
+    - Changeling
+    - Cliffscale
+    - Dar
+    - Frilled
+    - Makar
+    - Niasa
+    - Sandstrider
+    - Unseen
+    feats:
+      1:
+      - Ciith Lore
+      - Marsh Runner
+      - Parthenogenic Hatchling
+      - Razor Claws
+      - Reptile Speaker
+      - Sharp Fangs
+      - Tail Whip
+      5:
+      - Ciith Unarmed Cunning
+      - Envenom Fangs
+      - "Gecko's Grip"
+      - Shed Tail
+      - Swift Swimmer
+      9:
+      - Terrain Advantage
+      13:
+      - Primal Rampage
   Egalrin:
     HP: 6
     Size: M
     abl_boosts:
     - open
     - open
-    abl_flaw: ""
     languages:
     - Tradespeak
     - Egalrin
@@ -72,30 +174,25 @@ pf2e_ancestry:
         - finesse
         - unarmed
     heritages:
-    - Aasimar
+    - Aesa
     - Ashen One
     - Changeling
     - Dar
     - Jinxed-egalrin
     - Mountainkeeper
+    - Niasa    
     - Skyborn
     - Stormtossed
     - Taloned
-    - Tiefling
     feats:
       1:
       - Egalrin Lore
       - Egalrin Weapon Familiarity
-      - "Mariner's Fire"
       - "Scavenger's Search"
       - Squawk!
       - "Storm's Lash"
-      - Uncanny Agility
-      - Waxed Feathers
       5:
-      - Dogfang Bite
       - Eat Fortune
-      - Egalrin Feather Fan
       - Egalrin Weapon Study
       - Long-Nosed Form
       - Magpie Snatch
@@ -124,16 +221,15 @@ pf2e_ancestry:
     special:
     - Low-Light Vision
     heritages:
-    - Aasimar
+    - Aesa
     - Ashen One
     - Chameleon
     - Changeling
     - Dar
     - Fey-Touched
+    - Niasa
     - Sensate
-    - Tiefling
     - Umbral
-    - Vivacious
     - Wellspring
     feats:
       1:
@@ -143,27 +239,17 @@ pf2e_ancestry:
       - Fey Fellowship
       - First World Magic
       - Gnome Obsession
-      - Gnome Polyglot
       - Gnome Weapon Familiarity
-      - Grim Insight
       - Illusion Sense
-      - Inventive Offensive
-      - Life-Giving Magic
-      - Natural Performer
       - Razzle-Dazzle
-      - Theoretical Acumen
-      - Unexpected Shift
-      - Vibrant Display
       5:
       - Animal Elocutionist
+      - Energized Font
       - Gnome Weapon Innovator
-      - Intuitive Illusions
-      - Natural Illusionist
       - Project Persona
       9:
       - Cautious Curiosity
       - First World Adept
-      - Fortuitous Shift
       - Life Leap
       - Vivacious Conduit
       13:
@@ -171,7 +257,7 @@ pf2e_ancestry:
       - Instinctive Obfuscation
       17:
       - Homeward Bound
-  Gobber:
+  Goblin:
     HP: 6
     Size: S
     Speed: 25
@@ -180,117 +266,50 @@ pf2e_ancestry:
     - open
     languages:
     - Tradespeak
-    - Gobber
+    - Goblin
     traits:
     - goblin
     - humanoid
     special:
     - darkvision
     heritages:
-    - Aasimar
+    - Aesa
     - Ashen One
     - Changeling
     - Charhide
     - Dar
     - Irongut
+    - Niasa
     - Razortooth
     - Snow
-    - Tailed
-    - Tiefling
-    - Treedweller
     - Unbreakable
     feats:
       1:
-      - Bouncy Gobber
       - Burn It!
       - City Scavenger
       - Extra Squishy
-      - Fang Sharpener
-      - Gobber Lore
-      - Gobber Scuttle
-      - Gobber Song
-      - Gobber Weapon Familiarity
-      - Hard Tail
+      - Goblin Lore
+      - Goblin Scuttle
+      - Goblin Song
+      - Goblin Weapon Familiarity
       - Junk Tinker
       - Rough Rider
       - Twitchy
       - Very Sneaky
       5:
-      - Ankle Bite
-      - Gobber Weapon Frenzy
+      - Goblin Weapon Frenzy
       - Kneecap
       - Loud Singer
-      - Tail Spin
-      - Torch Gobber
-      - "Tree Climber (Gobber)"
       - Vandal
       9:
       - Cave Climber
       - Cling
-      - Freeze It!
-      - Hungry Gobber
-      - Roll With It
-      - Scalding Spit
       - Skittering Scuttle
       13:
-      - Gobber Weapon Expertise
-      - Unbreakable-er Gobber
+      - Goblin Weapon Expertise
       - "Very, Very Sneaky"
       17:
-      - Reckless Abandon
-  Egalrin:
-    HP: 6
-    Size: M
-    abl_boosts:
-    - open
-    - open
-    languages:
-    - Tradespeak
-    - Egalrin
-    traits:
-    - egalrin
-    - humanoid
-    special:
-    - Low-Light Vision
-    attack:
-      Beak:
-        damage: d6
-        damage_type: P
-        group: brawling
-        traits:
-        - finesse
-        - unarmed
-    heritages:
-    - Aasimar
-    - Ashen One
-    - Changeling
-    - Dar
-    - Jinxed-egalrin
-    - Mountainkeeper
-    - Skyborn
-    - Stormtossed
-    - Taloned
-    - Tiefling
-    feats:
-      1:
-      - Egalrin Lore
-      - Egalrin Weapon Familiarity
-      - "Scavenger's Search"
-      - Squawk!
-      - "Storm's Lash"
-      5:
-      - Eat Fortune
-      - Egalrin Weapon Study
-      - Fey Influence
-      - Long-Nosed Form
-      - One-Toed Hop
-      9:
-      - Eclectic Sword Training
-      - Soaring Flight
-      13:
-      - Egalrin Weapon Expertise
-      17:
-      - Great Egalrin Form
+      - "Reckless Abandon (Goblin)"
   Human:
     HP: 8
     Size: M
@@ -304,47 +323,35 @@ pf2e_ancestry:
     - human
     - humanoid
     heritages:
-    - Aasimar
+    - Aesa
     - Ashen One
     - Changeling
     - Dar
     - Half-Sil
     - Half-Oruch
+    - Niasa
     - Skilled
-    - Tiefling
     - Versatile
-    - Wintertouched
     feats:
       1:
       - Adapted Cantrip
-      - Arcane Tattoos
       - Cooperative Nature
       - General Training
-      - Gloomseer
       - Haughty Obstinacy
       - Natural Ambition
       - Natural Skill
       - Unconventional Weaponry
       5:
       - Adaptive Adept
-      - Clever Improviser
       - Sense Allies
       9:
       - Cooperative Soul
-      - Dragon Prince
       - Group Aid
       - Hardy Traveler
-      - Heir of the Saoc
-      - Incredible Improvisation
       - Multitalented
-      - Shory Aeromancer
-      - Virtue-Forged Tattoos
       13:
       - Advanced General Training
       - Bounce Back
-      - Irriseni Ice-Witch
-      - Shadow Pact
-      - Shory Aerialist
       - Stubborn Persistence
       - Unconventional Expertise
       17:
@@ -365,18 +372,16 @@ pf2e_ancestry:
     special:
     - Low-Light Vision
     heritages:
-    - Aasimar
+    - Aesa
     - Ashen One
     - Changeling
     - Dar
     - Deep Rat
     - Desert Rat
     - Longsnout Rat
+    - Niasa
     - Sewer Rat
     - Shadow Rat
-    - Snow Rat
-    - Tiefling
-    - Tunnel Rat
     feats:
       1:
       - Cheek Pouches
@@ -388,21 +393,15 @@ pf2e_ancestry:
       - Vicious Incisors
       - Warren Navigator
       5:
-      - Gnaw
-      - Kailli Roll
       - Lab Rat
-      - Plague Sniffer
-      - Quick Stow (Kailli)
+      - "Quick Stow (Kailli)"
       - Rat Magic
       9:
       - Big Mouth
       - Overcrowd
       - Rat Form
       13:
-      - Shinstabber
-      - Skittering Sneak
       - Warren Digger
-      - Kailli Growth
   Khazad:
     HP: 10
     Size: M
@@ -419,25 +418,23 @@ pf2e_ancestry:
     special:
     - Darkvision
     heritages:
-    - Aasimar
+    - Aesa
     - Ancient-Blooded
     - Anvil
     - Ashen One
     - Changeling
     - Dar
     - Death Warden
-    - Elemental Heart
     - Forge
-    - Oathkeeper
+    - Niasa
     - Rock
     - Strong-Blooded
-    - Tiefling
     feats:
       1:
+      - Eye For Treasure
       - Khazadi Doughtiness
       - Khazadi Lore
       - Khazadi Weapon Familiarity
-      - Eye For Treasure
       - Rock Runner
       - Stonecunning
       - Unburdened Iron
@@ -448,13 +445,8 @@ pf2e_ancestry:
       - Khazadi Reinforcement
       - Khazadi Weapon Cunning
       - Sheltering Slab
-      - "Tomb-Watcher's Glare"
       9:
-      - Battleforger
       - Echoes in Stone
-      - Energy Blessed
-      - "Heroes' Call"
-      - Kneel for No God
       - "Mountain's Stoutness"
       - Returning Throw
       - Stone Bones
@@ -464,175 +456,6 @@ pf2e_ancestry:
       - Telluric Power
       17:
       - Stonegate
-  Lizardfolk:
-    HP: 8
-    Size: M
-    Speed: 25
-    abl_boosts:
-    - open
-    - open
-    languages:
-    - Tradespeak
-    - Draconic
-    traits:
-    - lizardfolk
-    - humanoid
-    attack:
-      Claws:
-        damage: d4
-        damage_type: S
-        traits:
-        - agile
-        - finesse
-        - unarmed
-    bonus_feats:
-    - Breath Control
-    heritages:
-    - Aasimar
-    - Ashen One
-    - Changeling
-    - Cliffscale
-    - Dar
-    - Frilled
-    - Sandstrider
-    - Sith-Makar
-    - Unseen
-    - Tiefling
-
-    feats:
-      1:
-      - Lizardfolk Lore
-      - Marsh Runner
-      - Parthenogenetic Hatchling
-      - Razor Claws
-      - Reptile Speaker
-      - Sharp Fangs
-      - Tail Whip
-      5:
-      - Envenom Fangs
-      - Fey Influence
-      - "Gecko's Grip"
-      - Iruxi Unarmed Cunning
-      - Shed Tail
-      - Swift Swimmer
-      9:
-      - Terrain Advantage
-      13:
-      - Iruxi Unarmed Expertise
-  Lucht Siuil:
-    HP: 6
-    Size: S
-    Speed: 25
-    able_boosts:
-    - open
-    - open
-    languages:
-    - Tradespeak
-    - Bassin
-    traits:
-    - bassin
-    - humanoid
-    special:
-    - keen eyes
-    heritages:
-    - Aasimar
-    - Ashen One
-    - Changeling
-    - Dar
-    - Gutsy
-    - Hillock
-    - Jinxed-bassin
-    - Nomadic
-    - Observant
-    - Tiefling
-    - Twilight
-    - Wildwood
-    feats:
-      1:
-      - Distracting Shadows
-      - Folksy Patter
-      - Bassin Lore
-      - Bassin Luck
-      - Bassin Weapon Familiarity
-      - Prairie Rider
-      - Sure Feet
-      - Titan Slinger
-      - Unfettered Bassin
-      - Watchful Bassin
-      5:
-      - Cultural Adaptability
-      - Bassin Weapon Trickster
-      - Step Lively
-      9:
-      - Cunning Climber
-      - Dance Underfoot
-      - Fade Away
-      - Guiding Luck
-      - Helpful Bassin
-      - Irrepressible
-      - Unhampered Passage
-      13:
-      - Ceaseless Shadows
-      - Cobble Dancer
-      - Bassin Weapon Expertise
-      - "Incredible Luck (Bassin)"
-      - Toppling Dance
-      17:
-      - Shadow Self
-  Ciith:
-    HP: 8
-    Size: M
-    Speed: 25
-    abl_boosts:
-    - open
-    - open
-    abl_flaw: ""
-    languages:
-    - Tradespeak
-    - Draconic
-    traits:
-    - ciith
-    - humanoid
-    attack:
-      Claws:
-        damage: d4
-        damage_type: S
-        traits:
-        - agile
-        - finesse
-        - unarmed
-    bonus_feats:
-    - Breath Control
-    heritages:
-    - Aasimar
-    - Ashen One
-    - Changeling
-    - Cliffscale
-    - Dar
-    - Frilled
-    - Sandstrider
-    - Sith-Makar
-    - Unseen
-    - Tiefling
-    feats:
-      1:
-      - Ciith Lore
-      - Marsh Runner
-      - Parthenogenetic Hatchling
-      - Razor Claws
-      - Reptile Speaker
-      - Sharp Fangs
-      - Tail Whip
-      5:
-      - Envenom Fangs
-      - "Gecko's Grip"
-      - Iruxi Unarmed Cunning
-      - Shed Tail
-      - Swift Swimmer
-      9:
-      - Terrain Advantage
-      13:
-      - Iruxi Unarmed Expertise
   Oruch:
     HP: 10
     Size: M
@@ -640,8 +463,6 @@ pf2e_ancestry:
     abl_boosts:
     - open
     - open
-    - open
-    abl_flaw: ""
     languages:
     - Tradespeak
     - Yrch
@@ -651,15 +472,15 @@ pf2e_ancestry:
     special:
     - darkvision
     heritages:
-    - Aasimar
+    - Aesa
     - Ashen One
     - Badlands
     - Changeling
     - Dar
     - Deep
     - Hold-Scarred
+    - Niasa
     - Rainfall
-    - Tiefling
     feats:
       1:
       - Beast Trainer
@@ -702,16 +523,14 @@ pf2e_ancestry:
     special:
     - Low-Light Vision
     heritages:
-    - Aasimar
+    - Aesa
     - Ashen One
-    - Ancient
     - Arctic
     - Cavern
     - Changeling
     - Dar
-    - Desert
+    - Niasa
     - Seer
-    - Tiefling
     - Whisper
     - Woodland
     feats:
@@ -720,28 +539,25 @@ pf2e_ancestry:
       - Ancestral Longevity
       - Forlorn
       - Know Your Own
-      - Nimble Elf
+      - Nimble Sil
       - Otherworldly Magic
-      - Share Thoughts
-      - Silya Aloofness
-      - Silya Lore
-      - Silya Weapon Familiarity
+      - Sildanyari Aloofness
+      - Sildanyari Lore
+      - Sildanyari Weapon Familiarity
+      - Unwavering Mien
       5:
       - Ageless Patience
       - Ancestral Suspicion
       - Martial Experience
-      - Silya Weapon Elegance
+      - Sildanyari Weapon Elegance
       9:
-      - Brightness Seeker
-      - Elf Step
       - Expert Longevity
       - Otherworldly Acumen
-      - Sense Thoughts
-      - Tree Climber (Elf)
+      - Sildanyar Step
+      - Tree Climber (Sildanyar)
       13:
       - Avenge Ally
-      - Silya Weapon Expertise
+      - Sildanyari Weapon Expertise
       - Universal Longevity
-      - Wandering Heart
       17:
       - Magic Rider

--- a/game/config/pf2e_armor.yml
+++ b/game/config/pf2e_armor.yml
@@ -11,7 +11,7 @@ pf2e_armor:
     bulk: 0.1
     check_penalty: 0
     speed_penalty: 0
-    min_str: 8
+    min_str: 0
     group: Cloth
   Padded:
     category: light
@@ -30,6 +30,18 @@ pf2e_armor:
     category: light
     traits: []
     level: 0
+    price: 200
+    ac_bonus: 1
+    dex_cap: 4
+    check_penalty: -1
+    speed_penalty: 0
+    min_str: 10
+    bulk: 1
+    group: Leather
+  Studded Leather:
+    category: light
+    traits: []
+    level: 0
     price: 300
     ac_bonus: 2
     dex_cap: 3
@@ -38,18 +50,6 @@ pf2e_armor:
     min_str: 12
     bulk: 1
     group: Leather
-  Studded Leather:
-    category: light
-    traits: []
-    level: 0
-    price: 20
-    ac_bonus: 1
-    dex_cap: 3
-    check_penalty: -1
-    speed_penalty: 0
-    min_str: 10
-    bulk: 1
-    group: Cloth
   Chain Shirt:
     category: light
     traits:
@@ -61,7 +61,7 @@ pf2e_armor:
     dex_cap: 3
     check_penalty: -1
     speed_penalty: 0
-    min_str: 2
+    min_str: 12
     bulk: 1
     group: Chain
   Hide:
@@ -142,7 +142,7 @@ pf2e_armor:
     category: heavy
     traits:
     - bulwark
-    level: 02
+    level: 2
     price: 3000
     ac_bonus: 6
     dex_cap: 0

--- a/game/config/pf2e_backgrounds.yml
+++ b/game/config/pf2e_backgrounds.yml
@@ -24,15 +24,103 @@ pf2e_background:
     special: []
     action: []
     reaction: []
-  Animal Whisperer:
+  Animal Whisperer (Aquatic Terrain):
     abl_boosts:
-    - [ Constitution, Intelligence ]
+    - [ Wisdom, Charisma ]
     - open
     skills:
-    - Society
-    - Architecture Lore
+    - Nature
+    - Aquatic Terrain Lore
     feat:
-    - Additional Lore
+    - Train Animal
+    action: []
+    reaction: []
+  Animal Whisperer (Arctic Terrain):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Nature
+    - Aquatic Terrain Lore
+    feat:
+    - Train Animal
+    action: []
+    reaction: []
+  Animal Whisperer (Desert Terrain):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Nature
+    - Desert Terrain Lore
+    feat:
+    - Train Animal
+    action: []
+    reaction: []
+  Animal Whisperer (Forest Terrain):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Nature
+    - Forest Terrain Lore
+    feat:
+    - Train Animal
+    action: []
+    reaction: []
+  Animal Whisperer (Mountain Terrain):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Nature
+    - Mountain Terrain Lore
+    feat:
+    - Train Animal
+    action: []
+    reaction: []
+  Animal Whisperer (Plains Terrain):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Nature
+    - Plains Terrain Lore
+    feat:
+    - Train Animal
+    action: []
+    reaction: []
+  Animal Whisperer (Sky Terrain):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Nature
+    - Sky Terrain Lore
+    feat:
+    - Train Animal
+    action: []
+    reaction: []
+  Animal Whisperer (Swamp Terrain):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Nature
+    - Swamp Terrain Lore
+    feat:
+    - Train Animal
+    action: []
+    reaction: []
+  Animal Whisperer (Underground Terrain):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Nature
+    - Underground Terrain Lore
+    feat:
+    - Train Animal
     action: []
     reaction: []
   Artisan:
@@ -59,14 +147,109 @@ pf2e_background:
     special: []
     action: []
     reaction: []
-  Bandit:
+  Bandit (Aquatic Terrain):
     abl_boosts:
     - [ Dexterity, Charisma ]
     - open
     skills:
     - Intimidation
-    lores:
-    - terrain
+    - Aquatic Terrain Lore
+    feat:
+    - Group Coercion
+    special: []
+    action: []
+    reaction: []
+  Bandit (Arctic Terrain):
+    abl_boosts:
+    - [ Dexterity, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Arctic Terrain Lore
+    feat:
+    - Group Coercion
+    special: []
+    action: []
+    reaction: []
+  Bandit (Desert Terrain):
+    abl_boosts:
+    - [ Dexterity, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Desert Terrain Lore
+    feat:
+    - Group Coercion
+    special: []
+    action: []
+    reaction: []
+  Bandit (Forest Terrain):
+    abl_boosts:
+    - [ Dexterity, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Forest Terrain Lore
+    feat:
+    - Group Coercion
+    special: []
+    action: []
+    reaction: []
+  Bandit (Mountain Terrain):
+    abl_boosts:
+    - [ Dexterity, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Mountain Terrain Lore
+    feat:
+    - Group Coercion
+    special: []
+    action: []
+    reaction: []
+  Bandit (Plains Terrain):
+    abl_boosts:
+    - [ Dexterity, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Plains Terrain Lore
+    feat:
+    - Group Coercion
+    special: []
+    action: []
+    reaction: []
+  Bandit (Sky Terrain):
+    abl_boosts:
+    - [ Dexterity, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Sky Terrain Lore
+    feat:
+    - Group Coercion
+    special: []
+    action: []
+    reaction: []
+  Bandit (Swamp Terrain):
+    abl_boosts:
+    - [ Dexterity, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Swamp Terrain Lore
+    feat:
+    - Group Coercion
+    special: []
+    action: []
+    reaction: []
+  Bandit (Underground Terrain):
+    abl_boosts:
+    - [ Dexterity, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Underground Terrain Lore
     feat:
     - Group Coercion
     special: []
@@ -108,13 +291,255 @@ pf2e_background:
     special: []
     action: []
     reaction: []
-  Blessed:
+  Blessed (Althean):
     abl_boosts:
     - [ Wisdom, Charisma ]
     - open
-    lores:
-    - deity
+    skills:
+    - Althean Lore
     feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Angorite):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Angorite Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Animusian):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Animusian Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Caracorothan):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Caracorothan Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Ceinaran):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Ceinaran Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Daeusite):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Daeusite Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Danan):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Danan Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Deimosian):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Deimosian Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Elunan):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Elunan Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Gileadean):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Gileadean Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Gunakharan):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Gunakharan Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Illothan):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Illothan Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Korite):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Korite Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Maugrimite):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Maugrimite Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Navosian):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Navosian Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Radan):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Radan Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Reosian):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Reosian Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Serrielite):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Serrielite Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Taaran):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Taaran Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Tarienite):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Tarienite Lore
+    feat: []
+    special:
+    - Blessed
+    rare: true
+    action: []
+    reaction: []
+  Blessed (Thulite):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Thulite Lore
+    feat: []
+    special:
+    - Blessed
     rare: true
     action: []
     reaction: []
@@ -164,14 +589,73 @@ pf2e_background:
     special: []
     action: []
     reaction: []
-  Courier:
+  Courier (Alexandria):
     abl_boosts:
     - [ Dexterity, Intelligence ]
     - open
     skills:
     - Society
-    lores:
-    - city
+    - Alexandria Lore
+    feat:
+    - Glean Contents
+    special: []
+    action: []
+    reaction: []
+  Courier (Bryn Myridorn):
+    abl_boosts:
+    - [ Dexterity, Intelligence ]
+    - open
+    skills:
+    - Society
+    - Bryn Myridorn Lore
+    feat:
+    - Glean Contents
+    special: []
+    action: []
+    reaction: []
+  Courier (Dun Mordren):
+    abl_boosts:
+    - [ Dexterity, Intelligence ]
+    - open
+    skills:
+    - Society
+    - Dun Mordren Lore
+    feat:
+    - Glean Contents
+    special: []
+    action: []
+    reaction: []
+  Courier (Tashraan):
+    abl_boosts:
+    - [ Dexterity, Intelligence ]
+    - open
+    skills:
+    - Society
+    - Tashraan Lore
+    feat:
+    - Glean Contents
+    special: []
+    action: []
+    reaction: []
+  Courier (Hextus):
+    abl_boosts:
+    - [ Dexterity, Intelligence ]
+    - open
+    skills:
+    - Society
+    - Hextus Lore
+    feat:
+    - Glean Contents
+    special: []
+    action: []
+    reaction: []
+  Courier (Vandalheim):
+    abl_boosts:
+    - [ Dexterity, Intelligence ]
+    - open
+    skills:
+    - Society
+    - Vandalheim Lore
     feat:
     - Glean Contents
     special: []
@@ -189,14 +673,253 @@ pf2e_background:
     special: []
     action: []
     reaction: []
-  Cultist:
+  Cultist (Althean):
     abl_boosts:
     - [ Intelligence, Charisma ]
     - open
     skills:
     - Occultism
-    lores:
-    - deity
+    - Althean Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Angorite):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Angorite Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Animusian):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Animusian Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Caracorothan):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Caracorothan Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Ceinaran):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Ceinaran Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Daeusite):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Daeusite Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Danan):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Danan Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Deimosian):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Deimosian Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Elunan):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Elunan Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Gileadean):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Gileadean Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Gunakharan):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Gunakharan Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Illothan):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Illothan Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Korite):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Korite Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Maugrimite):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Maugrimite Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Navosian):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Navosian Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Radan):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Radan Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Reosian):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Reosian Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Serrielite):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Serrielite Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Taaran):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Taaran Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Tarienite):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Tarienite Lore
+    feat:
+    - Schooled In Secrets
+    special: []
+    action: []
+    reaction: []
+  Cultist (Thulite):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Occultism
+    - Thulite Lore
     feat:
     - Schooled In Secrets
     special: []
@@ -226,14 +949,73 @@ pf2e_background:
     special: []
     action: []
     reaction: []
-  Emissary:
+  Emissary (Alexandria):
     abl_boosts:
     - [ Intelligence, Charisma ]
     - open
     skills:
     - Society
-    lores:
-    - city
+    - Alexandria Lore
+    feat:
+    - Multilingual
+    special: []
+    action: []
+    reaction: []
+  Emissary (Bryn Myridorn):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Society
+    - Bryn Myridorn Lore
+    feat:
+    - Multilingual
+    special: []
+    action: []
+    reaction: []
+  Emissary (Dun Mordren):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Society
+    - Dun Mordren Lore
+    feat:
+    - Multilingual
+    special: []
+    action: []
+    reaction: []
+  Emissary (Tashraan):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Society
+    - Tashraan Lore
+    feat:
+    - Multilingual
+    special: []
+    action: []
+    reaction: []
+  Emissary (Hextus):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Society
+    - Hextus Lore
+    feat:
+    - Multilingual
+    special: []
+    action: []
+    reaction: []
+  Emissary (Vandalheim):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Society
+    - Vandalheim Lore
     feat:
     - Multilingual
     special: []
@@ -309,7 +1091,7 @@ pf2e_background:
     - Occultism
     - Fortune-Telling Lore
     feat:
-    - Lie To Me
+    - Oddity Identification
     special: []
   Gambler:
     abl_boosts:
@@ -357,42 +1139,6 @@ pf2e_background:
     special: []
     action: []
     reaction: []
-  Harrow-Led (Occultism):
-    abl_boost:
-    - open
-    skills:
-    - Occultism
-    - Harrow Lore
-    feat:
-    - Dubious Knowledge
-    special:
-    - Harrow
-    action: []
-    reaction: []
-  Harrow-Led (Performance):
-    abl_boost:
-    - open
-    skills:
-    - Performance
-    - Harrow Lore
-    feat:
-    - Dubious Knowledge
-    special:
-    - Harrow
-    action: []
-    reaction: []
-  Harrow-Led (Society):
-    abl_boost:
-    - open
-    skills:
-    - Society
-    - Harrow Lore
-    feat:
-    - Dubious Knowledge
-    special:
-    - Harrow
-    action: []
-    reaction: []
   Haunted:
     abl_boosts:
     - [ Wisdom, Charisma ]
@@ -414,32 +1160,6 @@ pf2e_background:
     - Herbalism Lore
     feat:
     - Natural Medicine
-    special: []
-    action: []
-    reaction: []
-  Hermit (Nature):
-    abl_boosts:
-    - [ Constitution, Intelligence ]
-    - open
-    skills:
-    - Nature
-    lores:
-    - terrain
-    feat:
-    - Dubious Knowledge
-    special: []
-    action: []
-    reaction: []
-  Hermit (Occultism):
-    abl_boosts:
-    - [ Constitution, Intelligence ]
-    - open
-    skills:
-    - Occultism
-    lores:
-    - terrain
-    feat:
-    - Dubious Knowledge
     special: []
     action: []
     reaction: []
@@ -488,7 +1208,6 @@ pf2e_background:
     - Warfare Lore
     feat:
     - Cat Fall
-    - Quick Jump
     special: []
     action: []
     reaction: []
@@ -500,7 +1219,6 @@ pf2e_background:
     - Athletics
     - Warfare Lore
     feat:
-    - Cat Fall
     - Quick Jump
     special: []
     action: []
@@ -513,7 +1231,7 @@ pf2e_background:
     - Diplomacy
     - Mercantile Lore
     feat:
-    - Bargain Hunter
+    - Eye for Numbers
     special: []
     action: []
     reaction: []
@@ -525,11 +1243,11 @@ pf2e_background:
     - Survival
     - Mining Lore
     feat:
-    - Terrain Expertise/Underground
+    - Terrain Expertise (Underground)
     special: []
     action: []
     reaction: []
-  Noble:
+  Noble (Genealogy Lore):
     abl_boosts:
     - [ Intelligence, Charisma ]
     - open
@@ -541,16 +1259,123 @@ pf2e_background:
     special: []
     action: []
     reaction: []
-  Nomad:
+  Noble (Heraldry Lore):
+    abl_boosts:
+    - [ Intelligence, Charisma ]
+    - open
+    skills:
+    - Society
+    - Heraldry Lore
+    feat:
+    - Courtly Graces
+    special: []
+    action: []
+    reaction: []
+  Nomad (Aquatic Terrain Lore):
     abl_boosts:
     - [ Constitution, Wisdom ]
     - open
     skills:
     - Survival
-    lores:
-    - terrain
+    - Aquatic Terrain Lore
     feat:
-    - Assurance/Survival
+    - Assurance (Survival)
+    special: []
+    action: []
+    reaction: []
+  Nomad (Arctic Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Arctic Terrain Lore
+    feat:
+    - Assurance (Survival)
+    special: []
+    action: []
+    reaction: []
+  Nomad (Desert Terrain Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Desert Terrain Lore
+    feat:
+    - Assurance (Survival)
+    special: []
+    action: []
+    reaction: []
+  Nomad (Forest Terrain Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Forest Terrain Lore
+    feat:
+    - Assurance (Survival)
+    special: []
+    action: []
+    reaction: []
+  Nomad (Mountain Terrain Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Mountain Terrain Lore
+    feat:
+    - Assurance (Survival)
+    special: []
+    action: []
+    reaction: []
+  Nomad (Plains Terrain Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Plains Terrain Lore
+    feat:
+    - Assurance (Survival)
+    special: []
+    action: []
+    reaction: []
+  Nomad (Sky Terrain Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Sky Terrain Lore
+    feat:
+    - Assurance (Survival)
+    special: []
+    action: []
+    reaction: []
+  Nomad (Swamp Terrain Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Swamp Terrain Lore
+    feat:
+    - Assurance (Survival)
+    special: []
+    action: []
+    reaction: []
+  Nomad (Underground Terrain Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Underground Terrain Lore
+    feat:
+    - Assurance (Survival)
     special: []
     action: []
     reaction: []
@@ -560,18 +1385,299 @@ pf2e_background:
     - open
     skills:
     - Nature
-    - Plains Lore
+    - Plains Terrain Lore
     feat:
     - Express Rider
     special: []
     action: []
     reaction: []
-  Pilgrim:
+  Pilgrim (Althean Lore):
     abl_boosts:
     - [ Wisdom, Charisma ]
     - open
     skills:
     - Religion
+    - Althean Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Angorite Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Angorite Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Animusian Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Animusian Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Caracorothan Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Caracorothan Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Ceinaran Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Ceinaran Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Daeusite Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Daeusite Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Danan Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Danan Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Deimosian Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Deimosian Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Elunan Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Elunan Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Gileadean Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Gileadean Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Gunakharan Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Gunakharan Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Illothan Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Illothan Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Korite Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Korite Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Maugrimite Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Maugrimite Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Navosian Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Navosian Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Radan Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Radan Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Reosian Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Reosian Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Serrielite Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Serrielite Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Taaran Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Taaran Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Tarienite Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Tarienite Lore
+    lores:
+    - deity
+    feat:
+    - "Pilgrim's Token"
+    special: []
+    action: []
+    reaction: []
+  Pilgrim (Thulite Lore):
+    abl_boosts:
+    - [ Wisdom, Charisma ]
+    - open
+    skills:
+    - Religion
+    - Thulite Lore
     lores:
     - deity
     feat:
@@ -591,14 +1697,181 @@ pf2e_background:
     special: []
     action: []
     reaction: []
-  Refugee:
+  Refugee (Alexandros Lore):
     abl_boosts:
     - [ Constitution, Wisdom ]
     - open
     skills:
     - Society
-    lores:
-    - city
+    - Alexandros Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Am'shere Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Am'shere Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Bludgun Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Bludgun Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Charn Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Charn Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Dragonier Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Dragonier Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Dran Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Dran Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Desolation Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Desolation Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Greatwoods Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Greatwoods Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Jade Islands Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Jade Islands Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Khazad Duin Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Khazad Duin Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Myrddion Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Myrddion Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Rune Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Rune Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Sturmvargd Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Sturmvargd Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Vast Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Vast Lore
+    feat:
+    - Streetwise
+    special: []
+    action: []
+    reaction: []
+  Refugee (Veyshan Lore):
+    abl_boosts:
+    - [ Constitution, Wisdom ]
+    - open
+    skills:
+    - Society
+    - Veyshan Lore
     feat:
     - Streetwise
     special: []
@@ -609,10 +1882,9 @@ pf2e_background:
     - [ Constitution, Wisdom ]
     - open
     skills: 
-    - Boneyard Lore
+    - Great Halls Lore
     feat:
     - Diehard
-    - Additional Lore/Boneyard Lore
     special: []
     rare: true
     action: []
@@ -638,18 +1910,184 @@ pf2e_background:
     - Sailing Lore
     feat:
     - Underwater Marauder
-    - Cat Fall
     special: []
     action: []
     reaction: []
-  Scavenger:
+  Scavenger (Alexandros Lore):
     abl_boosts:
     - [ Intelligence, Wisdom ]
     - open
     skills:
     - Survival
-    lores:
-    - city
+    - Alexandros Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Am'shere Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Am'shere Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Bludgun Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Bludgun Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Charn Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Charn Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Dragonier Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Dragonier Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Dran Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Dran Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Desolation Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Desolation Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Greatwoods Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Greatwoods Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Jade Islands Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Jade Islands Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Khazad Duin Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Khazad Duin Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Myrddion Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Myrddion Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Rune Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Rune Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Sturmvargd Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Sturmvargd Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Vast Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Vast Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scavenger (Veyshan Lore):
+    abl_boosts:
+    - [ Intelligence, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Veyshan Lore
     feat:
     - Forager
     special: []
@@ -662,7 +2100,8 @@ pf2e_background:
     skills:
     - Arcana
     - Academia Lore
-    feat: []
+    feat:
+    - Assurance (Arcana)
     special: []
     action: []
     reaction: []
@@ -673,7 +2112,8 @@ pf2e_background:
     skills:
     - Nature
     - Academia Lore
-    feat: []
+    feat:
+    - Assurance (Nature)
     special: []
     action: []
     reaction: []
@@ -684,7 +2124,8 @@ pf2e_background:
     skills:
     - Occultism
     - Academia Lore
-    feat: []
+    feat:
+    - Assurance (Occultism)
     special: []
     action: []
     reaction: []
@@ -695,18 +2136,102 @@ pf2e_background:
     skills:
     - Religion
     - Academia Lore
-    feat: []
+    feat:
+    - Assurance (Religion)
     special: []
     action: []
     reaction: []
-  Scout:
+  Scout (Aquatic Terrain Lore):
     abl_boosts:
     - [ Dexterity, Wisdom ]
     - open
     skills:
     - Survival
-    lores:
-    - terrain
+    - Aquatic Terrain Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scout (Arctic Lore):
+    abl_boosts:
+    - [ Dexterity, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Arctic Terrain Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scout (Desert Terrain Lore):
+    abl_boosts:
+    - [ Dexterity, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Desert Terrain Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scout (Forest Terrain Lore):
+    abl_boosts:
+    - [ Dexterity, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Forest Terrain Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scout (Mountain Terrain Lore):
+    abl_boosts:
+    - [ Dexterity, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Mountain Terrain Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scout (Plains Terrain Lore):
+    abl_boosts:
+    - [ Dexterity, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Plains Terrain Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scout (Sky Terrain Lore):
+    abl_boosts:
+    - [ Dexterity, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Sky Terrain Lore
+    feat:
+    - Forager
+    special: []
+    action: []
+    reaction: []
+  Scout (Swamp Terrain Lore):
+    abl_boosts:
+    - [ Dexterity, Wisdom ]
+    - open
+    skills:
+    - Survival
+    - Swamp Terrain Lore
     feat:
     - Forager
     special: []
@@ -721,30 +2246,6 @@ pf2e_background:
     - Labor Lore
     feat:
     - Read Lips
-    special: []
-    action: []
-    reaction: []
-  Spell Seeker (Arcana):
-    abl_boosts:
-    - [ Intelligence, Wisdom ]
-    - open
-    skills:
-    - Arcana
-    - Library Lore
-    feat:
-    - Recognize Spell
-    special: []
-    action: []
-    reaction: []
-  Spell Seeker (Occultism):
-    abl_boosts:
-    - [ Intelligence, Wisdom ]
-    - open
-    skills:
-    - Occultism
-    - Library Lore
-    feat:
-    - Recognize Spell
     special: []
     action: []
     reaction: []
@@ -772,27 +2273,253 @@ pf2e_background:
     special: []
     action: []
     reaction: []
-  Street Urchin:
+  Street Urchin (Alexandria Lore):
     abl_boosts:
     - [ Dexterity, Constitution ]
     - open
     skills:
     - Thievery
-    lores:
-    - city
+    - Alexandria Lore
     feat:
     - Pickpocket
     special: []
     action: []
     reaction: []
-  Tax Collector:
+  Street Urchin (Bryn Myridorn Lore):
+    abl_boosts:
+    - [ Dexterity, Constitution ]
+    - open
+    skills:
+    - Thievery
+    - Bryn Myridorn Lore
+    feat:
+    - Pickpocket
+    special: []
+    action: []
+    reaction: []
+  Street Urchin (Dun Mordren Lore):
+    abl_boosts:
+    - [ Dexterity, Constitution ]
+    - open
+    skills:
+    - Thievery
+    - Dun Mordren Lore
+    feat:
+    - Pickpocket
+    special: []
+    action: []
+    reaction: []
+  Street Urchin (Tashraan Lore):
+    abl_boosts:
+    - [ Dexterity, Constitution ]
+    - open
+    skills:
+    - Thievery
+    - Tashraan Lore
+    feat:
+    - Pickpocket
+    special: []
+    action: []
+    reaction: []
+  Street Urchin (Hextus Lore):
+    abl_boosts:
+    - [ Dexterity, Constitution ]
+    - open
+    skills:
+    - Thievery
+    - Hextus Lore
+    feat:
+    - Pickpocket
+    special: []
+    action: []
+    reaction: []
+  Street Urchin (Vandalheim Lore):
+    abl_boosts:
+    - [ Dexterity, Constitution ]
+    - open
+    skills:
+    - Thievery
+    - Vandalheim Lore
+    feat:
+    - Pickpocket
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Alexandros Lore):
     abl_boosts:
     - [ Strength, Charisma ]
     - open
     skills:
     - Intimidation
-    lores:
-    - city
+    - Alexandros Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Am'shere Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Am'shere Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Bludgun Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Bludgun Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Charn Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Charn Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Dragonier Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Dragonier Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Dran Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Dran Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Desolation Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Desolation Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Greatwoods Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Greatwoods Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Jade Islands Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Jade Islands Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Khazad Duin Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Khazad Duin Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Myrddion Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Myrddion Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Rune Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Rune Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Sturmvargd Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Sturmvargd Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Vast Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Vast Lore
+    feat:
+    - Quick Coercion
+    special: []
+    action: []
+    reaction: []
+  Tax Collector (Veyshan Lore):
+    abl_boosts:
+    - [ Strength, Charisma ]
+    - open
+    skills:
+    - Intimidation
+    - Veyshan Lore
     feat:
     - Quick Coercion
     special: []

--- a/game/config/pf2e_feat_ancestry.yml
+++ b/game/config/pf2e_feat_ancestry.yml
@@ -1,5 +1,6 @@
 ---
 pf2e_feats:
+# Arvek Ancestry Feats
   Alchemical Scholar:
     feat_type: 
     - Ancestry
@@ -43,24 +44,6 @@ pf2e_feats:
     - Arvek
     traits: []
     shortdesc: 'You’re skilled at beating a foe when their morale is already breaking.'
-    prereq:
-      level: 1
-  Sneaky:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Arvek
-    traits: []
-    shortdesc: Stealth is an important tool in your arsenal.
-    prereq:
-      level: 1
-  Stone Face:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Arvek
-    traits: []
-    shortdesc: Through conditioning or experience, you've mastered the art of composure, even in the face of fear.
     prereq:
       level: 1
   Vigorous Health:
@@ -111,24 +94,244 @@ pf2e_feats:
     prereq:
       level: 5
       combat_stats: wp_martial/trained
-  Recognize Ambush:
+# Bassin Ancestry Feats
+  Bassin Lore:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Arvek
+    - Bassin
     traits: []
-    shortdesc: Your combat training has honed you to be ready for an attack at all times.
+    shortdesc: You’ve dutifully learned important skills passed down through generations of halfling tradition.
     prereq:
-      level: 5
-  Runtsage:
+      level: 1
+  Bassin Luck:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Arvek
+    - Bassin
+    traits:
+    - fortune
+    shortdesc: Your happy-go-lucky nature makes it seem like misfortune avoids you.
+    prereq:
+      level: 1
+  Bassin Weapon Familiarity:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
     traits: []
-    shortdesc: Unlike most of your kind, who dismiss goblins as embarrassments or expendable annoyances, you have studied the methodology behind their irresponsible and incomprehensible actions.
+    shortdesc: You favor traditional halfling weapons, so you’ve learned how to use them more effectively.
+    prereq:
+      level: 1
+  Distracting Shadows:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
+    traits: []
+    shortdesc: You have learned to remain hidden by using larger folk as a distraction to avoid drawing attention to yourself.
+    prereq:
+      level: 1
+  Folksy Patter:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
+    traits: []
+    shortdesc: You are adept at disguising coded messages as folksy idioms.
+    prereq:
+      level: 1
+  Prairie Rider:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
+    traits: []
+    shortdesc: You grew up riding your clan's shaggy ponies and riding dogs.
+    prereq:
+      level: 1
+  Sure Feet:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
+    traits:
+    - bassin
+    shortdesc: Whether keeping your balance or scrambling up a tricky climb, your hairy, calloused feet easily find purchase.
+    prereq:
+      level: 1
+  Titan Slinger:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
+    traits: []
+    shortdesc: You have learned how to use your sling to fell enormous creatures.
+    prereq:
+      level: 1
+  Unfettered Bassin:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
+    traits: []
+    shortdesc: You were forced into service as a laborer, but you’ve since escaped and have trained to ensure you’ll never be caught again.
+    prereq:
+      level: 1
+  Watchful Bassin:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
+    traits: []
+    shortdesc: Your communal lifestyle causes you to pay close attention to the people around you.
+    prereq:
+      level: 1
+  Bassin Weapon Trickster:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
+    traits: []
+    shortdesc: You are particularly adept at fighting with your people’s favored weapons.
     prereq:
       level: 5
+      feat: 
+      - Bassin Weapon Familiarity
+  Cultural Adaptability:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
+    traits: []
+    shortdesc: During your adventures, you’ve honed your ability to adapt to the culture of the predominant ancestry around you.
+    prereq:
+      level: 5
+  Step Lively:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Bassin
+    traits: []
+    shortdesc: You are an expert at avoiding the lumbering footsteps of larger creatures.
+    prereq:
+      level: 5
+# Ciith Ancestry Feats
+  Ciith Lore:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: You listened carefully to the tales passed down among your community.
+    prereq:
+      level: 1
+  Marsh Runner:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: You are adept at moving through marshy terrain.
+    prereq:
+      level: 1
+  Parthenogenic Hatchling:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: You were hatched from an unfertilized egg during hard times for your people, and you are a biological copy of your mother.
+    prereq:
+      level: 1
+  Razor Claws:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: Your have honed your claws to be deadly.
+    prereq:
+      level: 1
+  Reptile Speaker:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: You hear the sounds of reptiles as language.
+    prereq:
+      level: 1
+  Sharp Fangs:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: Your teeth are formidable weapons.
+    prereq:
+      level: 1
+  Tail Whip:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: By birth or through training, your tail is strong enough to make for a powerful melee weapon.
+    prereq:
+      level: 1
+  Ciith Unarmed Cunning:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: You make the most of your unarmed attacks.
+    prereq:
+      level: 5
+  Envenom Fangs:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: You envenom your fangs.
+    prereq:
+      level: 5
+      feat: 
+      - Sharp Fangs
+  Gecko's Grip:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: You stick to walls with a preternatural grip.
+    prereq:
+      level: 5
+      heritage: Cliffscale
+  Shed Tail:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: You can shed your tail to escape.
+    prereq:
+      level: 5
+      feat: 
+      - Tail Whip 
+  Swift Swimmer:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Ciith
+    traits: []
+    shortdesc: You swim faster than most ciith.
+    prereq:
+      level: 5
+      heritage: Makar
+# Egalrin Ancestry Feats
   Egalrin Lore:
     feat_type: 
     - Ancestry
@@ -145,15 +348,6 @@ pf2e_feats:
     - Egalrin
     traits: []
     shortdesc: You've trained with a blade and other tengu weapons ever since you hatched.
-    prereq:
-      level: 1
-  Mariner's Fire:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Egalrin
-    traits: []
-    shortdesc: 
     prereq:
       level: 1
   Scavenger's Search:
@@ -183,35 +377,6 @@ pf2e_feats:
     shortdesc: Wind and lightning have always been close friends to you.
     prereq:
       level: 1
-  Uncanny Agility:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Egalrin
-    traits: []
-    shortdesc: You've trained with a blade and other tengu weapons ever since you hatched.
-    prereq:
-      level: 1
-  Waxed Feathers:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Egalrin
-    traits: []
-    shortdesc: You've trained with a blade and other tengu weapons ever since you hatched.
-    prereq:
-      level: 1
-      heritage: Wavediver
-  Dogfang Bite:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Egalrin
-    traits: []
-    shortdesc: You can swing your beak to slash your foes when piercing attacks won't do.
-    prereq:
-      level: 5
-      heritage: Dogtooth
   Eat Fortune:
     feat_type: 
     - Ancestry
@@ -222,15 +387,6 @@ pf2e_feats:
     - divination
     - divine
     shortdesc: As someone tries to twist fate, you consume the interference.
-    prereq:
-      level: 5
-  Egalrin Feather Fan:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Egalrin
-    traits: []
-    shortdesc: You've learned to bind some of your feathers together into a fan to focus your ancestral magic.
     prereq:
       level: 5
   Egalrin Weapon Study:
@@ -275,6 +431,7 @@ pf2e_feats:
     shortdesc: Assuming a peculiar stance, you make a short hop on each toe.
     prereq:
       level: 5
+# Gnome Ancestry Feats
   Animal Accomplice:
     feat_type: 
     - Ancestry
@@ -325,6 +482,7 @@ pf2e_feats:
     shortdesc: Your connection to the First World grants you a primal innate spell, much like those of the fey.
     prereq:
       level: 1
+    init_magic: true
   Gnome Obsession:
     feat_type: 
     - Ancestry
@@ -332,15 +490,6 @@ pf2e_feats:
     - Gnome
     traits: []
     shortdesc: You might have a flighty nature, but when a topic captures your attention, you dive into it headfirst.
-    prereq:
-      level: 1
-  Gnome Polyglot:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gnome
-    traits: []
-    shortdesc: Your extensive travels, curiosity, and love of learning help you to learn languages quickly.
     prereq:
       level: 1
   Gnome Weapon Familiarity:
@@ -352,16 +501,6 @@ pf2e_feats:
     shortdesc: You favor unusual weapons tied to your people, such as blades with curved and peculiar shapes.
     prereq:
       level: 1
-  Grim Insight:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gnome
-    traits: []
-    shortdesc: Others’ attempts to scare you often grant you insights about your would-be bullies that you can then exploit.
-    prereq:
-      level: 1
-      heritage: Umbral
   Illusion Sense:
     feat_type: 
     - Ancestry
@@ -369,33 +508,6 @@ pf2e_feats:
     - Gnome
     traits: []
     shortdesc: Your ancestors spent their days cloaked and cradled in illusions, and as a result, sensing illusion magic is second nature to you.
-    prereq:
-      level: 1
-  Inventive Offensive:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gnome
-    traits: []
-    shortdesc: You can jury-rig your weapons to perform in unexpected ways.
-    prereq:
-      level: 1
-  Life-Giving Magic:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gnome
-    traits: []
-    shortdesc: The upwelling of innate magic refreshes your body.
-    prereq:
-      level: 1
-  Natural Performer:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gnome
-    traits: []
-    shortdesc: Entertainment comes naturally to you.
     prereq:
       level: 1
   Razzle-Dazzle:
@@ -407,34 +519,6 @@ pf2e_feats:
     shortdesc: You've spent considerable time practicing the manipulation of light, weaponizing your blade's reflection or bolstering the luminosity of magical displays to unconventional heights.
     prereq:
       level: 1
-  Theoretical Acumen:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gnome
-    traits: []
-    shortdesc: You study a creature’s form and behavior to hypothesize likely means of overcoming its strengths.
-    prereq:
-      level: 1
-  Unexpected Shift:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gnome
-    traits: []
-    shortdesc: Your supernatural connection sometimes causes you to phase from reality when under threat, disappearing for split seconds before reappearing -- often surprising you as much as your enemies.
-    prereq:
-      level: 1
-  Vibrant Display:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gnome
-    traits: []
-    shortdesc: Whereas most gnomes’ coloration is static or changes slowly, you can cause your hair, eye, and skin color to scintillate in brief and disorienting bursts.
-    prereq:
-      level: 1
-      heritage: Chameleon
   Animal Elocutionist:
     feat_type: 
     - Ancestry
@@ -446,6 +530,16 @@ pf2e_feats:
       level: 5
       feat: 
       - Burrow Elocutionist
+  Energized Font:
+    feat_type:
+    - Ancestry
+    assoc_ancestry:
+    - Gnome
+    traits: []
+    shortdesc: The magic within you provides increased energy you can use to focus.
+    prereq:
+      level: 5
+    init_magic: true
   Gnome Weapon Innovator:
     feat_type: 
     - Ancestry
@@ -457,28 +551,6 @@ pf2e_feats:
       level: 5
       feat: 
       - Gnome Weapon Familiarity
-  Intuitive Illusions:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gnome
-    traits: []
-    shortdesc: Illusion magic comes to you so naturally that you can effortlessly sustain your magical ruses.
-    prereq:
-      level: 5
-      feat: 
-      - Illusion Sense
-  Natural Illusionist:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gnome
-    traits: []
-    shortdesc: By drawing upon the First World’s magic, you can siphon a portion of that malleable world to create a convincing illusion.
-    prereq:
-      level: 5
-      feat: 
-      - Illusion Sense
   Project Persona:
     feat_type: 
     - Ancestry
@@ -492,21 +564,12 @@ pf2e_feats:
     shortdesc: Where others etch their armor to serve as a conduit for their imaginations, your vivid mind and bold personality allow you to project a more fitting persona over your lackluster armor.
     prereq:
       level: 5
-  Bouncy Gobber:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gobber
-    traits: []
-    shortdesc: You have a particular elasticity that makes it easy for you to bounce and squish.
-    prereq:
-      level: 1
-      heritage: Unbreakable
+# Goblin Ancestry Feats
   Burn It!:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: Fire fascinates you.
     prereq:
@@ -515,7 +578,7 @@ pf2e_feats:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: You know that the greatest treasures often look like refuse, and you scoff at those who throw away perfectly good scraps.
     prereq:
@@ -524,73 +587,53 @@ pf2e_feats:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: Your rubbery physique makes it easier for you to wedge yourself into tight spaces and more difficult for your enemies to dislodge you.
     prereq:
       level: 1
       heritage: Unbreakable
-  Fang Sharpener:
+  Goblin Lore:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
-    traits: []
-    shortdesc: You have filed your teeth into jagged points and have an unusually powerful jaw, making your mouth a dangerous weapon.
-    prereq:
-      level: 1
-      heritage: Razortooth
-  Gobber Lore:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: You’ve picked up skills and tales from your goblin community.
     prereq:
       level: 1
-  Gobber Scuttle:
+  Goblin Scuttle:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: You take advantage of your ally’s movement to adjust your position.
     prereq:
       level: 1
-  Gobber Song:
+  Goblin Song:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: You sing annoying goblin songs, distracting your foes with silly and repetitive lyrics.
     prereq:
       level: 1
-  Gobber Weapon Familiarity:
+  Goblin Weapon Familiarity:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: Others might look upon them with disdain, but you know that the weapons of your people are as effective as they are sharp.
     prereq:
       level: 1
-  Hard Tail:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gobber
-    traits: []
-    shortdesc: Your tail is much stronger than most, and you can lash out with it with the strength of a whip.
-    prereq:
-      level: 1
-      heritage: Tailed
   Junk Tinker:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: You can make useful tools out of even twisted or rusted scraps.
     prereq:
@@ -599,7 +642,7 @@ pf2e_feats:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: You are especially good at riding traditional gobber mounts.
     prereq:
@@ -608,7 +651,7 @@ pf2e_feats:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: You are naturally suspicious and wary of danger, especially when you suspect someone might be leading you into an ambush.
     prereq:
@@ -617,26 +660,16 @@ pf2e_feats:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: Taller folk rarely pay attention to the shadows at their feet, and you take full advantage of this.
     prereq:
       level: 1
-  Ankle Bite:
+  Goblin Weapon Frenzy:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
-    traits: []
-    shortdesc: Whenever someone grabs onto you, you instinctively bite down hard.
-    prereq:
-      level: 5
-      heritage: Razorooth
-  Gobber Weapon Frenzy:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: You know how to wield your people’s vicious weapons.
     prereq:
@@ -645,7 +678,7 @@ pf2e_feats:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: You deliver a punishing blow to an enemy's knee, shin, or other vulnerable anatomy within your reach.
     prereq:
@@ -654,55 +687,23 @@ pf2e_feats:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: 'Staying on pitch, proper breath control, and remembering the words are all less important than the real measure of a good singer: volume! The range of your Goblin Song is increased to 60 feet, and you can target one additional enemy when you use it.'
     prereq:
       level: 5
       feat: 
       - Goblin Song
-  Tail Spin:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gobber
-    traits: []
-    shortdesc: You excel at using your tail as a weapon to upend your foes.
-    prereq:
-      level: 5
-      feat: 
-      - Hard Tail
-  Torch Goblin:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gobber
-    traits: []
-    shortdesc: You’ve spent enough time on fire that you know how to use it to your advantage.
-    prereq:
-      level: 5
-      heritage: Charhide
-  Tree Climber (Gobber):
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Gobber
-    traits: []
-    shortdesc: Your time in forest or jungle canopies has taught you how to scramble across branches with sure feet.
-    prereq:
-      level: 5
-      orheritage: 
-      - Tailed 
-      - Treedweller
   Vandal:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Gobber
+    - Goblin
     traits: []
     shortdesc: You have a knack for breaking and dismantling things.
     prereq:
       level: 5
+# Human Ancestry Feats
   Adapted Cantrip:
     feat_type: 
     - Ancestry
@@ -712,6 +713,7 @@ pf2e_feats:
     shortdesc: Through study of multiple magical traditions, you’ve altered a spell to suit your spellcasting style.
     prereq:
       level: 1
+    init_magic: true
   Cooperative Nature:
     feat_type: 
     - Ancestry
@@ -794,7 +796,8 @@ pf2e_feats:
     traits: []
     shortdesc: You have developed a soul-deep bond with your comrades and maintain an even greater degree of cooperation with them.
     prereq:
-      level: 5
+      level: 9
+# Kailli Ancestry Feats
   Cheek Pouches:
     feat_type: 
     - Ancestry
@@ -867,27 +870,6 @@ pf2e_feats:
     shortdesc: You're particularly good at solving mazes and navigating twists and turns.
     prereq:
       level: 1
-  Gnaw:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Kailli
-    traits: []
-    shortdesc: With enough time and determination, you can chew through nearly anything.
-    prereq:
-      level: 5
-      feat: 
-      - Vicious Incisors
-  Kailli Roll:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Kailli
-    traits:
-    - move
-    shortdesc: Your ability to curl up into a tight ball comes in handy.
-    prereq:
-      level: 5
   Lab Rat:
     feat_type: 
     - Ancestry
@@ -897,16 +879,6 @@ pf2e_feats:
     shortdesc: You've spent more than your share of time in an alchemy lab.
     prereq:
       level: 5
-  Plague Sniffer:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Kailli
-    traits: []
-    shortdesc: You can sniff out the pungent tang of disease.
-    prereq:
-      level: 5
-      heritage: Longsnout
   Quick Stow (Kailli):
     feat_type: 
     - Ancestry
@@ -927,6 +899,17 @@ pf2e_feats:
     shortdesc: There always seems to be a little rat around to carry messages for you.
     prereq:
       level: 5
+    init_magic: true
+# Khazadi Ancestry Feats
+  Eye for Treasure:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Khazad
+    traits: []
+    shortdesc: You know good artisanship when you see it and can wax poetic about crafting techniques and forms.
+    prereq:
+      level: 1
   Khazadi Doughtiness:
     feat_type: 
     - Ancestry
@@ -952,15 +935,6 @@ pf2e_feats:
     - Khazad
     traits: []
     shortdesc: Your kin have instilled in you an affinity for hard-hitting weapons, and you prefer these to more elegant arms.
-    prereq:
-      level: 1
-  Eye for Treasure:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Khazad
-    traits: []
-    shortdesc: You know good artisanship when you see it and can wax poetic about crafting techniques and forms.
     prereq:
       level: 1
   Rock Runner:
@@ -1050,261 +1024,7 @@ pf2e_feats:
     shortdesc: The stone around you is your ally, and you have learned to use it to shore up your weaknesses.
     prereq:
       level: 5
-  Tomb-Watcher's Glare:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Khazad
-    traits: []
-    shortdesc: When you critically hit an undead creature, or an undead creature critically fails a saving throw against one of your abilities, you drive your divine wrath home in your enemy’s heart. The undead is enfeebled 1 for 1 round.
-    prereq:
-      level: 5
-      heritage: Death Warden
-  Bassin Luck:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits:
-    - fortune
-    shortdesc: Your happy-go-lucky nature makes it seem like misfortune avoids you.
-    prereq:
-      level: 1
-  Distracting Shadows:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: You have learned to remain hidden by using larger folk as a distraction to avoid drawing attention to yourself.
-    prereq:
-      level: 1
-  Folksy Patter:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: You are adept at disguising coded messages as folksy idioms.
-    prereq:
-      level: 1
-  Bassin Lore:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: You’ve dutifully learned important skills passed down through generations of halfling tradition.
-    prereq:
-      level: 1
-  Bassin Weapon Familiarity:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: You favor traditional halfling weapons, so you’ve learned how to use them more effectively.
-    prereq:
-      level: 1
-  Prairie Rider:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: You grew up riding your clan's shaggy ponies and riding dogs.
-    prereq:
-      level: 1
-  Sure Feet:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits:
-    - bassin
-    shortdesc: Whether keeping your balance or scrambling up a tricky climb, your hairy, calloused feet easily find purchase.
-    prereq:
-      level: 1
-  Titan Slinger:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: You have learned how to use your sling to fell enormous creatures.
-    prereq:
-      level: 1
-  Unfettered Bassin:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: You were forced into service as a laborer, but you’ve since escaped and have trained to ensure you’ll never be caught again.
-    prereq:
-      level: 1
-  Watchful Bassin:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: Your communal lifestyle causes you to pay close attention to the people around you.
-    prereq:
-      level: 1
-  Cultural Adaptability:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: During your adventures, you’ve honed your ability to adapt to the culture of the predominant ancestry around you.
-    prereq:
-      level: 5
-  Bassin Weapon Trickster:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: You are particularly adept at fighting with your people’s favored weapons.
-    prereq:
-      level: 5
-      feat: 
-      - Bassin Weapon Familiarity
-  Step Lively:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Bassin
-    traits: []
-    shortdesc: You are an expert at avoiding the lumbering footsteps of larger creatures.
-    prereq:
-      level: 5
-  Ciith Lore:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: You listened carefully to the tales passed down among your community.
-    prereq:
-      level: 1
-  Marsh Runner:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: You are adept at moving through marshy terrain.
-    prereq:
-      level: 1
-  Parthenogenic Hatchling:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: You were hatched from an unfertilized egg during hard times for your people, and you are a biological copy of your mother.
-    prereq:
-      level: 1
-  Razor Claws:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: Your have honed your claws to be deadly.
-    prereq:
-      level: 1
-  Reptile Speaker:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: You hear the sounds of reptiles as language.
-    prereq:
-      level: 1
-  Sharp Fangs:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: Your teeth are formidable weapons.
-    prereq:
-      level: 1
-  Tail Whip:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: By birth or through training, your tail is strong enough to make for a powerful melee weapon.
-    prereq:
-      level: 1
-  Envenom Fangs:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: You envenom your fangs.
-    prereq:
-      level: 5
-      feat: 
-      - Sharp Fangs
-  Gecko's Grip:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: You stick to walls with a preternatural grip.
-    prereq:
-      level: 5
-      heritage: Cliffscale
-  Ciith Unarmed Cunning:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: You make the most of your unarmed attacks.
-    prereq:
-      level: 5
-  Shed Tail:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: You can shed your tail to escape.
-    prereq:
-      level: 5
-      feat: 
-      - Tail Whip 
-  Swift Swimmer:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Ciith
-    traits: []
-    shortdesc: You swim faster than most iruxi.
-    prereq:
-      level: 5
-      heritage: Wetlander
-  Oruch Superstition:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Oruch
-    traits:
-    - concentrate
-    shortdesc: You defend yourself against magic by relying on techniques derived from oruch cultural superstitions.
-    prereq:
-      level: 1
+# Oruch Ancestry Feats
   Beast Trainer:
     feat_type: 
     - Ancestry
@@ -1339,6 +1059,16 @@ pf2e_feats:
     - Oruch
     traits: []
     shortdesc: The hold elders taught you your people's histories, told tales of great athletic feats, and shared with you the hardships your ancestors endured so that you can pass this wisdom down to future generations.
+    prereq:
+      level: 1
+  Oruch Superstition:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Oruch
+    traits:
+    - concentrate
+    shortdesc: You defend yourself against magic by relying on techniques derived from oruch cultural superstitions.
     prereq:
       level: 1
   Oruch Weapon Familiarity:
@@ -1418,6 +1148,7 @@ pf2e_feats:
     shortdesc: Your victories in battle fill you with pride and imbue you with the energy to fight a bit longer despite your wounds.
     prereq:
       level: 5
+# Sildanyar Ancestry Feats
   Ancestral Linguistics:
     feat_type: 
     - Ancestry
@@ -1434,33 +1165,6 @@ pf2e_feats:
     - Sildanyar
     traits: []
     shortdesc: You have accumulated a vast array of lived knowledge over the years.
-    prereq:
-      level: 1
-  Sildanyari Aloofness:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Sildanyar
-    traits: []
-    shortdesc: As much as you might care for them, you've come to terms with the ephemeral nature of non-sil, and it makes their threats feel less troublesome.
-    prereq:
-      level: 1
-  Sildanyari Lore:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Sildanyar
-    traits: []
-    shortdesc: You’ve studied in traditional sildanyari arts, learning about arcane magic and the world around you.
-    prereq:
-      level: 1
-  Sildanyari Weapon Familiarity:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Sildanyar
-    traits: []
-    shortdesc: You favor bows and other elegant weapons.
     prereq:
       level: 1
   Forlorn:
@@ -1497,6 +1201,34 @@ pf2e_feats:
     - Sildanyar
     traits: []
     shortdesc: Your sildanyari magic manifests as a simple arcane spell, even if you aren’t formally trained in magic.
+    prereq:
+      level: 1
+    init_magic: true
+  Sildanyari Aloofness:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Sildanyar
+    traits: []
+    shortdesc: As much as you might care for them, you've come to terms with the ephemeral nature of non-sil, and it makes their threats feel less troublesome.
+    prereq:
+      level: 1
+  Sildanyari Lore:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Sildanyar
+    traits: []
+    shortdesc: You’ve studied in traditional sildanyari arts, learning about arcane magic and the world around you.
+    prereq:
+      level: 1
+  Sildanyari Weapon Familiarity:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Sildanyar
+    traits: []
+    shortdesc: You favor bows and other elegant weapons.
     prereq:
       level: 1
   Unwavering Mien:
@@ -1546,7 +1278,8 @@ pf2e_feats:
       level: 5
       feat: 
       - Sildanyari Weapon Familiarity
-
+# Heritage and Versatile Heritage Feats
+# Aesa Ancestry Feats
   Angelkin:
     feat_type: 
     - Ancestry
@@ -1555,7 +1288,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1563,12 +1296,12 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - aasimar
+    - aesa
     - lineage
-    shortdesc: You descend from an angel—a winged messenger from Nirvana or one of the other celestial realms—which gives you a knack for cultures and languages.
+    shortdesc: You descend from an angel, which gives you a knack for cultures and languages.
     prereq:
       level: 1
-      heritage: Aasimar
+      heritage: Aesa
   Celestial Eyes:
     feat_type: 
     - Ancestry
@@ -1577,7 +1310,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1585,11 +1318,11 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - aasimar
+    - aesa
     shortdesc: You can see through darkness.
     prereq:
       level: 1
-      heritage: Aasimar
+      heritage: Aesa
   Celestial Lore:
     feat_type: 
     - Ancestry
@@ -1598,7 +1331,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1606,11 +1339,11 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - aasimar
-    shortdesc: You were raised with an aasimar or celestial relative, or you've devoted yourself to researching the secrets of the celestial realms.
+    - aesa
+    shortdesc: You were raised with an aesa or celestial relative, or you've devoted yourself to researching the secrets of the celestial realms.
     prereq:
       level: 1
-      heritage: Aasimar
+      heritage: Aesa
   Halo:
     feat_type: 
     - Ancestry
@@ -1619,7 +1352,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1627,11 +1360,11 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - aasimar
+    - aesa
     shortdesc: You are surrounded by a halo of light and goodness at all times.
     prereq:
       level: 1
-      heritage: Aasimar
+      heritage: Aesa
   Lawbringer:
     feat_type: 
     - Ancestry
@@ -1640,7 +1373,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1648,12 +1381,12 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - aasimar
+    - aesa
     - lineage
     shortdesc: 'You trace your lineage to archons: embodiments of heavenly virtues, guardians of the seven-tiered mountain of Heaven, and nurturers of law and virtue within mortals.'
     prereq:
       level: 1
-      heritage: Aasimar
+      heritage: Aesa
   Musetouched:
     feat_type: 
     - Ancestry
@@ -1662,7 +1395,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1670,13 +1403,13 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - aasimar
+    - aesa
     - lineage
     shortdesc: Your blood sings with the liberating power of the azatas, living embodiments of freedom from the wild realm of Elysium.
     prereq:
       level: 1
-      heritage: Aasimar
-  Blessed Blood (Aasimar):
+      heritage: Aesa
+  Blessed Blood (Aesa):
     feat_type: 
     - Ancestry
     assoc_ancestry: 
@@ -1684,7 +1417,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1692,11 +1425,11 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - aasimar
+    - aesa
     shortdesc: Your freshly spilled blood is sanctified, and ingesting it causes effects similar to those of holy water.
     prereq:
       level: 5
-      heritage: Aasimar
+      heritage: Aesa
   Celestial Resistance:
     feat_type: 
     - Ancestry
@@ -1705,7 +1438,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1713,11 +1446,11 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - aasimar
+    - aesa
     shortdesc: Your growing connection to your celestial forebears has granted you one of their resistances as well.
     prereq:
       level: 5
-      heritage: Aasimar
+      heritage: Aesa
   Empyreal Blessing:
     feat_type: 
     - Ancestry
@@ -1726,7 +1459,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1734,32 +1467,12 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - aasimar
+    - aesa
     shortdesc: You can call forth a benediction upon your allies, whether you pray to a deity of the celestial realms or just find the power within yourself.
     prereq:
       level: 5
-      heritage: Aasimar
-  Healer's Halo:
-    feat_type: 
-    - Ancestry
-    assoc_ancestry: 
-    - Arvek
-    - Bassin
-    - Ciith 
-    - Egalrin
-    - Gobber
-    - Gnome
-    - Human
-    - Kailli
-    - Khazad
-    - Oruch
-    - Sildanyar
-    traits:
-    - aasimar
-    shortdesc: Your halo can enhance positive energy.
-    prereq:
-      level: 5
-      heritage: Aasimar
+      heritage: Aesa
+# Ashen One Ancestry Feats
   Ashen Lore:
     feat_type: 
     - Ancestry
@@ -1768,7 +1481,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1789,7 +1502,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1810,7 +1523,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1831,7 +1544,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1854,7 +1567,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1875,7 +1588,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1888,6 +1601,7 @@ pf2e_feats:
     prereq:
       level: 5
       heritage: Ashen One
+# Changeling Ancestry Feats
   Brine May:
     feat_type: 
     - Ancestry
@@ -1896,7 +1610,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1918,7 +1632,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1940,7 +1654,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1961,7 +1675,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -1983,7 +1697,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2004,7 +1718,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2025,7 +1739,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2047,7 +1761,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2068,7 +1782,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2081,7 +1795,7 @@ pf2e_feats:
     prereq:
       level: 5
       heritage: Changeling
-
+# Dar Ancestry Feats
   Eyes Of The Night:
     feat_type: 
     - Ancestry
@@ -2090,7 +1804,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2111,7 +1825,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2132,7 +1846,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2154,7 +1868,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2176,7 +1890,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2197,7 +1911,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2210,6 +1924,70 @@ pf2e_feats:
     prereq:
       level: 1
       heritage: Dar
+  Enthralling Allure:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - dar
+    shortdesc: The powers of domination employed by your progenitors have manifested in you as well.
+    prereq:
+      level: 5
+      heritage: Dar
+  Necromantic Physiology:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - dar
+    shortdesc: Your unusual physiology has developed in a way that makes it difficult for parasites and other infestations to prey upon you.
+    prereq:
+      level: 5
+      heritage: Dar
+  Undead Slayer:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - dar
+    shortdesc: Your knowledge of your own not-quite-living anatomy, combined with your experience in combat, helps you take down undead foes with ease.
+    prereq:
+      level: 5
+      heritage: Dar   
+# Half-Sil Ancestry Feats
   Earned Glory:
     feat_type: 
     - Ancestry
@@ -2218,7 +1996,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2239,7 +2017,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2260,7 +2038,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2277,21 +2055,13 @@ pf2e_feats:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
-    - Arvek
-    - Bassin
-    - Ciith 
-    - Egalrin
-    - Gobber
-    - Gnome
     - Human
-    - Kailli
-    - Khazad
-    - Oruch
-    - Sildanyar
     shortdesc: The elven magic in your blood manifests as a force you can use to become more appealing or alluring.
     prereq:
       level: 5
       heritage: Half-Sil
+    init_magic: true
+# Half-Oruch Ancestry Feats
   Monstrous Peacemaker:
     feat_type: 
     - Ancestry
@@ -2300,7 +2070,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2321,7 +2091,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2334,7 +2104,7 @@ pf2e_feats:
     prereq:
       level: 1
       heritage: Half-Oruch
-
+# Niasa Ancestry Feats
   Fiendish Eyes:
     feat_type: 
     - Ancestry
@@ -2343,7 +2113,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2351,11 +2121,11 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - tiefling
+    - niasa
     shortdesc: You can see in the darkness as easily as a fiend.
     prereq:
       level: 1
-      heritage: Tiefling
+      heritage: Niasa
   Fiendish Lore:
     feat_type: 
     - Ancestry
@@ -2364,7 +2134,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2372,11 +2142,11 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - tiefling
-    shortdesc: You were raised by a tiefling or a fiendish relative, or you've devoted yourself to researching the secrets of the fiendish realms.
+    - niasa
+    shortdesc: You were raised by a niasa or a fiendish relative, or you've devoted yourself to researching the secrets of the fiendish realms.
     prereq:
       level: 1
-      heritage: Tiefling
+      heritage: Niasa
   Form of the Fiend:
     feat_type: 
     - Ancestry
@@ -2385,7 +2155,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2393,11 +2163,11 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - tiefling
+    - niasa
     shortdesc: Part of your body has an obvious, fiendish appearance.
     prereq:
       level: 1
-      heritage: Tiefling
+      heritage: Niasa
   Grimspawn:
     feat_type: 
     - Ancestry
@@ -2406,7 +2176,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2415,11 +2185,11 @@ pf2e_feats:
     - Sildanyar
     traits:
     - lineage
-    - tiefling
+    - niasa
     shortdesc: Your lineage traces back to a daemon, one of the manifestations of horrific forms of death that devour souls within their foul home of Abaddon.
     prereq:
       level: 1
-      heritage: Tiefling
+      heritage: Niasa
   Hellspawn:
     feat_type: 
     - Ancestry
@@ -2428,7 +2198,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2437,11 +2207,11 @@ pf2e_feats:
     - Sildanyar
     traits:
     - lineage
-    - tiefling
+    - niasa
     shortdesc: Your lineage descends from devils, the conniving schemers of Hell's malevolent hierarchy.
     prereq:
       level: 1
-      heritage: Tiefling
+      heritage: Niasa
   Nimble Hooves:
     feat_type: 
     - Ancestry
@@ -2450,7 +2220,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2458,11 +2228,11 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - tiefling
+    - niasa
     shortdesc: Your legs end in hooves rather than feet, with joints and tendons that allow you to move with great haste.
     prereq:
       level: 1
-      heritage: Tiefling
+      heritage: Niasa
   Pitborn:
     feat_type: 
     - Ancestry
@@ -2471,7 +2241,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2480,11 +2250,11 @@ pf2e_feats:
     - Sildanyar
     traits:
     - lineage
-    - tiefling
+    - niasa
     shortdesc: Your blood bears the mark of a demon, a living embodiment of sin from the fetid depths of the Abyss.
     prereq:
       level: 1
-      heritage: Tiefling
+      heritage: Niasa
   Fiendish Resistance:
     feat_type: 
     - Ancestry
@@ -2493,7 +2263,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2501,11 +2271,11 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - tiefling
+    - niasa
     shortdesc: Your connection to your fiendish forebears has granted you one of their resistances as well.
     prereq:
       level: 5
-      heritage: Tiefling
+      heritage: Niasa
   Malicious Bane:
     feat_type: 
     - Ancestry
@@ -2514,7 +2284,7 @@ pf2e_feats:
     - Bassin
     - Ciith 
     - Egalrin
-    - Gobber
+    - Goblin
     - Gnome
     - Human
     - Kailli
@@ -2522,8 +2292,8 @@ pf2e_feats:
     - Oruch
     - Sildanyar
     traits:
-    - tiefling
+    - niasa
     shortdesc: Whether your heart is pure or corrupt, you can call forth a malediction upon your foes.
     prereq:
       level: 5
-      heritage: Tiefling
+      heritage: Niasa

--- a/game/config/pf2e_feat_class.yml
+++ b/game/config/pf2e_feat_class.yml
@@ -1,5 +1,6 @@
 ---
 pf2e_feats:
+# A Class Feats
   Accelerating Touch:
     assoc_charclass:
       - Champion
@@ -52,7 +53,7 @@ pf2e_feats:
       level: 2
     shortdesc: You push back as you block the attack, knocking your foe away or off balance.
     traits: []
-  Alchemical Discoveries:
+  Alchemical Discoveries: #Formula Revisit
     assoc_charclass:
       - Investigator
     feat_type:
@@ -120,6 +121,7 @@ pf2e_feats:
       level: 4
     shortdesc: You are so connected with the animal world that you can grant yourself an animal's features and abilities.
     traits: []
+    init_magic: true
   Anoint Ally:
     assoc_charclass:
       - Sorcerer
@@ -174,6 +176,7 @@ pf2e_feats:
         - NG
     shortdesc: You stand strong in the face of danger and inspire your allies to do the same.
     traits: []
+# B Class Feats
   Bardic Lore:
     assoc_charclass:
       - Bard
@@ -216,6 +219,7 @@ pf2e_feats:
       level: 2
     shortdesc: Your patron grants you a special lesson, revealing a hidden facet of its nature.
     traits: []
+    init_magic: true
   Battle Assessment:
     assoc_charclass:
       - Rogue
@@ -265,6 +269,7 @@ pf2e_feats:
     shortdesc: Throwing your weight behind your attack, you hit you opponent hard enough to make it stumble back.
     traits:
       - press
+# C Class Feats
   Cackle:
     assoc_charclass:
       - Witch
@@ -274,6 +279,7 @@ pf2e_feats:
       level: 1
     shortdesc: You can extend one of your spells with a quick burst of laughter.
     traits: []
+    init_magic: true
   Calculated Splash:
     assoc_charclass:
       - Alchemist
@@ -304,7 +310,7 @@ pf2e_feats:
       level: 2
     shortdesc: You call upon the creatures of nature to come to your aid.
     traits: []
-  Cauldron:
+  Cauldron: #Crafting Revist
     assoc_charclass:
       - Witch
     feat_type:
@@ -472,6 +478,7 @@ pf2e_feats:
       level: 2
     shortdesc: Like a powerful constrictor, you crush targets in your unyielding grasp.
     traits: []
+# D Class Feats
   Dancing Leaf:
     assoc_charclass:
       - Monk
@@ -517,6 +524,7 @@ pf2e_feats:
       level: 1
     shortdesc: You embody an aspect of your deity.
     traits: []
+    init_magic: true
   Demolition Charge:
     assoc_charclass:
       - Alchemist
@@ -589,6 +597,7 @@ pf2e_feats:
       level: 4
     shortdesc: Your ability to tap into divine magic surpasses the spells traditionally available to you (the divine spell list).
     traits: []
+    init_magic: true
   Divine Aegis:
     assoc_charclass:
       - Oracle
@@ -642,6 +651,7 @@ pf2e_feats:
       level: 2
     shortdesc: Every oracle's mystery touches on a divine domain of the deities that fuel it; you can access that power.
     traits: []
+    init_magic: true
   Domain Initiate:
     assoc_charclass:
       - Cleric
@@ -651,6 +661,7 @@ pf2e_feats:
       level: 1
     shortdesc: Your deity bestows a special spell related to their powers.
     traits: []
+    init_magic: true
   Double Shot:
     assoc_charclass:
       - Fighter
@@ -743,7 +754,8 @@ pf2e_feats:
       level: 2
     shortdesc: You can parry attacks against you with your one-handed weapon.
     traits: []
-  Efficient Alchemy (Alchemist):
+# E Class Feats
+  Efficient Alchemy (Alchemist): #Crafting Revisit
     assoc_charclass:
       - Alchemist
     feat_type:
@@ -847,7 +859,7 @@ pf2e_feats:
       - Champion
     prereq:
       level: 2
-    shortdesc: You've sworn an oath to slay the alien abominations that lurk in the remote corners of Golarion.
+    shortdesc: You've sworn an oath to slay the alien abominations that lurk in the remote corners of Ea.
     traits:
       - oath
   Esoteric Polymath:
@@ -870,6 +882,7 @@ pf2e_feats:
     shortdesc: You make a controlled attack, fully accounting for your momentum.
     traits:
       - press
+# F Class Feats
   Familiar's Language:
     assoc_charclass:
       - Witch
@@ -991,6 +1004,7 @@ pf2e_feats:
     shortdesc: Desperate to finish the fight, you pour all your rage into one final blow.
     traits:
       - rage
+# G Class Feats
   Glean Lore:
     assoc_charclass:
       - Oracle
@@ -1022,6 +1036,7 @@ pf2e_feats:
       level: 1
     shortdesc: Your expertise with your weapons and commitment to taking out your targets lends you magical power.
     traits: []
+    init_magic: true
   Guarded Movement:
     assoc_charclass:
       - Monk
@@ -1031,6 +1046,7 @@ pf2e_feats:
       level: 4
     shortdesc: Your guard is up, even while moving.
     traits: []
+# H Class Feats
   Hand of the Apprentice:
     assoc_charclass:
       - Wizard
@@ -1040,6 +1056,7 @@ pf2e_feats:
       level: 1
     shortdesc: You can magically hurl your weapon at your foe.
     traits: []
+    init_magic: true
   Harming Hands:
     assoc_charclass:
       - Cleric
@@ -1068,7 +1085,8 @@ pf2e_feats:
       level: 1
     shortdesc: You have a deep devotion to your animal companion that enables you to magically heal their wounds.
     traits: []
-  Healing Bomb:
+    init_magic: true
+  Healing Bomb: #Crafting Revisit
     assoc_charclass:
       - Alchemist
     feat_type:
@@ -1127,6 +1145,7 @@ pf2e_feats:
       level: 4
     shortdesc: Your recollection of monsters is magically enhanced by luck.
     traits: []
+    init_magic: true
   Hymn of Healing:
     assoc_charclass:
       - Bard
@@ -1134,8 +1153,10 @@ pf2e_feats:
       - Charclass
     prereq:
       level: 1
-    shortdesc: You learn the hymn of healing composition spell (page 228), which imbues your music with rich melodies that help your allies recover from harm.
+    shortdesc: You learn the hymn of healing composition spell, which imbues your music with rich melodies that help your allies recover from harm.
     traits: []
+    init_magic: true
+# I Class Feats
   Improved Communal Healing:
     assoc_charclass:
       - Cleric
@@ -1188,6 +1209,7 @@ pf2e_feats:
       - emotion
       - fear
       - mental
+# K Class Feats
   Ki Rush:
     assoc_charclass:
       - Monk
@@ -1197,6 +1219,7 @@ pf2e_feats:
       level: 1
     shortdesc: You can use ki to move with extraordinary speed and make yourself harder to hit.
     traits: []
+    init_magic: true
   Ki Strike:
     assoc_charclass:
       - Monk
@@ -1206,6 +1229,7 @@ pf2e_feats:
       level: 1
     shortdesc: Your study of the flow of mystical energy allows you to harness it into your physical strikes.
     traits: []
+    init_magic: true
   Knockdown:
     assoc_charclass:
       - Fighter
@@ -1226,6 +1250,7 @@ pf2e_feats:
       level: 1
     shortdesc: Whenever you Devise a Stratagem, you can also attempt a check to Recall Knowledge as part of that action.
     traits: []
+# L Class Feats
   Leshy Familiar:
     assoc_charclass:
       - Druid
@@ -1266,8 +1291,9 @@ pf2e_feats:
     prereq:
       level: 1
       specialize: maestro
-    shortdesc: By adding a flourish, you make your compositions last longer.
+    shortdesc: By adding a flourish, you make your compositions last longer with the lingering composition spell.
     traits: []
+    init_magic: true
   Linked Focus:
     assoc_charclass:
       - Wizard
@@ -1306,6 +1332,7 @@ pf2e_feats:
       level: 2
     shortdesc: Extending your body to its limits, you attack an enemy that would normally be beyond your reach.
     traits: []
+# M Class Feats
   Magic Hide:
     assoc_charclass:
       - Ranger
@@ -1315,6 +1342,7 @@ pf2e_feats:
       level: 2
     shortdesc: You can defend your companion in battle.
     traits: []
+    init_magic: true
   Magical Trickster:
     assoc_charclass:
       - Rogue
@@ -1456,6 +1484,7 @@ pf2e_feats:
       level: 2
     shortdesc: Your muse doesn’t fall into a single label.
     traits: []
+# N Class Feats
   Nimble Dodge:
     assoc_charclass:
       - Rogue
@@ -1486,6 +1515,7 @@ pf2e_feats:
     traits:
       - manipulate
       - metamagic
+# O Class Feats
   Occult Evolution:
     assoc_charclass:
       - Sorcerer
@@ -1546,6 +1576,7 @@ pf2e_feats:
     shortdesc: With a great heave, you seize a piece of your surroundings, such as a boulder, log, table, wagon, or chunk of earth, and hurl it at your foes.
     traits:
       - rage
+# P Class Feats
   Parting Shot:
     assoc_charclass:
       - Fighter
@@ -1660,6 +1691,7 @@ pf2e_feats:
     shortdesc: You can call upon the creatures of the wild for aid.
     traits:
       - primal
+# Q Class Feats
   Quick Bomber:
     assoc_charclass:
       - Alchemist
@@ -1680,6 +1712,7 @@ pf2e_feats:
     traits:
       - flourish
       - press
+# R Class Feats
   Radiant Infusion:
     assoc_charclass:
       - Cleric
@@ -1834,6 +1867,7 @@ pf2e_feats:
       level: 4
     shortdesc: You can reload your weapon on the move.
     traits: []
+# S Class Feats
   Sabotage:
     assoc_charclass:
       - Rogue
@@ -1980,6 +2014,7 @@ pf2e_feats:
       level: 2
     shortdesc: You can magically move your snares around.
     traits: []
+    init_magic: true
   Snare Specialist:
     assoc_charclass:
       - Ranger
@@ -2009,8 +2044,9 @@ pf2e_feats:
     prereq:
       level: 2
       specialize: Warrior
-    shortdesc: Your performances inspire strength in your allies.
+    shortdesc: Your performances inspire strength in your allies with the song of strength composition cantrip.
     traits: []
+    init_magic: true
   Soothing Mist:
     assoc_charclass:
       - Ranger
@@ -2020,6 +2056,7 @@ pf2e_feats:
       level: 4
     shortdesc: You have a connection to the healing properties of nature and can produce a magical mist to heal damage and stop burning or bleeding.
     traits: []
+    init_magic: true
   Spellbook Prodigy:
     assoc_charclass:
       - Wizard
@@ -2229,8 +2266,9 @@ pf2e_feats:
       - Charclass
     prereq:
       level: 4
-    shortdesc: You learn to speed up yourself and your allies with your performance.
+    shortdesc: You learn to speed up yourself and your allies with your performance with the triple time composition cantrip.
     traits: []
+    init_magic: true
   Tumble Behind (Rogue):
     assoc_charclass:
       - Rogue
@@ -2289,6 +2327,7 @@ pf2e_feats:
     shortdesc: You swiftly attack your hunted prey with both weapons.
     traits:
       - flourish
+# U Class Feats
   Unbalancing Blow:
     assoc_charclass:
       - Rogue
@@ -2327,6 +2366,7 @@ pf2e_feats:
       specialize: Liberator
     shortdesc: With a burst of divine liberation, your spur your ally’s movement.
     traits: []
+# V Class Feats
   Vengeful Oath:
     assoc_charclass:
       - Champion
@@ -2386,6 +2426,8 @@ pf2e_feats:
       level: 4
     shortdesc: You can call upon divine insights to single out your foes' weak points.
     traits: []
+    init_magic: true
+# W Class Feats
   Weight of Guilt:
     assoc_charclass:
       - Champion
@@ -2414,6 +2456,7 @@ pf2e_feats:
       level: 4
     shortdesc: You can restore your health by tapping into your ki.
     traits: []
+    init_magic: true
   Widen Spell:
     assoc_charclass:
       - Druid
@@ -2448,6 +2491,7 @@ pf2e_feats:
       specialize: Wild
     shortdesc: You are one with the wild, always changing and adapting to meet any challenge.
     traits: []
+    init_magic: true
   Wolf Stance:
     assoc_charclass:
       - Monk
@@ -2486,6 +2530,7 @@ pf2e_feats:
       level: 4
     shortdesc: You roar in pain, awakening the rage within you.
     traits: []
+# Y Class Feats
   You're Next:
     assoc_charclass:
       - Rogue

--- a/game/config/pf2e_feat_general.yml
+++ b/game/config/pf2e_feat_general.yml
@@ -1,5 +1,6 @@
 ---
 pf2e_feats:
+# Level 1 General Feats
   Adopted Ancestry:
     feat_type: 
     - General
@@ -79,15 +80,6 @@ pf2e_feats:
     shortdesc: Ward off a blow with your shield.
     prereq:
       level: 1
-  Skill Training:
-    feat_type: 
-    - General
-    - Skill
-    traits: []
-    shortdesc: Become trained in a skill.
-    prereq:
-      level: 1
-      ability: Intelligence/12
   Toughness:
     feat_type: 
     - General
@@ -102,6 +94,7 @@ pf2e_feats:
     shortdesc: Become trained in a weapon type.
     prereq:
       level: 1
+# Level 3 General Feats
   Ancestral Paragon:
     feat_type: 
     - General

--- a/game/config/pf2e_feat_skill.yml
+++ b/game/config/pf2e_feat_skill.yml
@@ -1,5 +1,6 @@
 ---
 pf2e_feats:
+# Level 1 Feats
   Acrobatic Performer:
     feat_type: 
     - Skill
@@ -9,28 +10,25 @@ pf2e_feats:
     shortdesc: Use Acrobatics to Perform.
     prereq:
       level: 1
-      skill: Acrobatics/trained
-  Assurance (Acrobatics):
-    feat_type: 
+      skill: Acrobatics/trained  
+  Additional Lore:
+    feat_type:
     - Skill
     - General
-    assoc_skill: Acrobatics
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Acrobatics/trained
-  Cat Fall:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Acrobatics
     traits: []
-    shortdesc: Treat falls as shorter than they are.
+    shortdesc: Become trained in another Lore subcategory.
     prereq:
       level: 1
-      skill: Acrobatics/trained
+  Alchemical Crafting:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Crafting
+    traits: []
+    shortdesc: Craft alchemical items.
+    prereq:
+      level: 1
+      skill: Crafting/trained
   Arcane Sense:
     feat_type: 
     - Skill
@@ -41,46 +39,6 @@ pf2e_feats:
     prereq:
       level: 1
       skill: Arcana/trained
-  Assurance (Arcana):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Arcana
-    traits:
-    - fortune 
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Arcana/trained
-  Automatic Knowledge (Arcana):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Arcana
-    traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
-    prereq:
-      level: 2
-  Assured Identification (Arcane):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Arcana
-    traits: []
-    shortdesc: Avoid misidentifying magic.
-    prereq:
-      level: 2
-      skill: Arcana/expert
-  Magical Shorthand (Arcane):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Arcana
-    traits: []
-    shortdesc: Learn spells quickly and at a reduced cost.
-    prereq:
-      level: 2
-      skill: Arcana/expert
   Armor Assist:
     feat_type: 
     - Skill
@@ -93,6 +51,28 @@ pf2e_feats:
       orskill: 
       - Athletics/trained 
       - Warfare Lore/trained
+  Assurance (Acrobatics):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Acrobatics
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Acrobatics/trained
+  Assurance (Arcana):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Arcana
+    traits:
+    - fortune 
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Arcana/trained
   Assurance (Athletics):
     feat_type: 
     - Skill
@@ -104,96 +84,6 @@ pf2e_feats:
     prereq:
       level: 1
       skill: Athletics/trained
-  Combat Climber:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Athletics
-    traits: []
-    shortdesc: Fight more effectively as you Climb.
-    prereq:
-      level: 1
-      skill: Athletics/trained
-  Hefty Hauler:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Athletics
-    traits: []
-    shortdesc: Increase your Bulk limits by 2.
-    prereq:
-      level: 1
-      skill: Athletics/trained
-  Quick Jump:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Athletics
-    traits: []
-    shortdesc: High Jump or Long Jump as a single action.
-    prereq:
-      level: 1
-      skill: Athletics/trained
-  Titan Wrestler:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Athletics
-    traits: []
-    shortdesc: Disarm, Grapple, Shove, or Trip larger creatures.
-    prereq:
-      level: 1
-      skill: Athletics/trained
-  Underwater Marauder:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Athletics
-    traits: []
-    shortdesc: Fight more effectively underwater.
-    prereq:
-      level: 1
-      skill: Athletics/trained
-  Lead Climber:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Athletics
-    traits: []
-    shortdesc: Make Climbing safer for allies who Follow the Expert.
-    prereq:
-      level: 2
-      skill: Athletics/expert
-  Powerful Leap:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Athletics
-    traits: []
-    shortdesc: Jump farther and higher.
-    prereq:
-      level: 2
-      skill: Athletics/expert
-  Rapid Mantel:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Athletics
-    traits: []
-    shortdesc: Pull yourself onto ledges quickly.
-    prereq:
-      level: 2
-      skill: Athletics/expert
-  Alchemical Crafting:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Crafting
-    traits: []
-    shortdesc: Craft alchemical items.
-    prereq:
-      level: 1
-      skill: Crafting/trained
   Assurance (Crafting):
     feat_type: 
     - Skill
@@ -205,6 +95,215 @@ pf2e_feats:
     prereq:
       level: 1
       skill: Crafting/trained
+  Assurance (Deception):
+    feat_type: 
+    - General
+    - Skill
+    assoc_skill: Deception
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Deception/trained
+  Assurance (Diplomacy):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Diplomacy
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Diplomacy/trained
+  Assurance (Intimidation):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Intimidation
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Intimidation/trained
+  Assurance (Medicine):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Medicine
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Medicine/trained
+  Assurance (Nature):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Nature/trained
+  Assurance (Occultism):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Occultism/trained
+  Assurance (Performance):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Performance
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Performance/trained
+  Assurance (Religion):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Religion/trained
+  Assurance (Society):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Society/trained
+  Assurance (Stealth):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Stealth
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Stealth/trained
+  Assurance (Survival):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Assurance (Thievery):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Thievery
+    traits:
+    - fortune
+    shortdesc: Receive a fixed result on a skill check.
+    prereq:
+      level: 1
+      skill: Thievery/trained
+  Battle Medicine:
+    feat_type: 
+    - General
+    - Skill
+    assoc_skill: Medicine
+    traits:
+    - healing
+    - manipulate
+    shortdesc: Heal yourself or an ally in battle.
+    prereq:
+      level: 1
+      skill: Medicine/trained
+  Bon Mot:
+    feat_type: 
+    - Skill
+    assoc_skill: Diplomacy
+    traits:
+    - auditory
+    - concentrate
+    - emotion
+    - general
+    - linguistic
+    - mental
+    shortdesc: Distract a foe with a witty quip.
+    prereq:
+      level: 1
+      skill: Diplomacy/trained
+  Cat Fall:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Acrobatics
+    traits: []
+    shortdesc: Treat falls as shorter than they are.
+    prereq:
+      level: 1
+      skill: Acrobatics/trained
+  Charming Liar:
+    feat_type: 
+    - General
+    - Skill
+    assoc_skill: Deception
+    traits: []
+    shortdesc: Improve a target's attitude with your lies.
+    prereq:
+      level: 1
+      skill: Deception/trained
+  Combat Climber:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: Fight more effectively as you Climb.
+    prereq:
+      level: 1
+      skill: Athletics/trained
+  Concealing Legerdemain:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Thievery
+    traits: []
+    shortdesc: Conceal an Object using Thievery instead of Stealth.
+    prereq:
+      level: 1
+      skill: Thievery/trained
+  Courtly Graces:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: Use Society to get along in noble society.
+    prereq:
+      level: 1
+      skill: Society/trained
   Crafter's Appraisal:
     feat_type: 
     - Skill
@@ -215,6 +314,218 @@ pf2e_feats:
     prereq:
       level: 1
       skill: Crafting/trained
+  Deceptive Worship:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: Pass yourself off as a member of a religion.
+    prereq:
+      level: 1
+      skill: Occultism/trained
+  Dubious Knowledge (Arcana):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Arcana
+    traits: []
+    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    prereq:
+      level: 1
+      skill: Arcana/trained
+  Dubious Knowledge (Crafting):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Crafting
+    traits: []
+    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    prereq:
+      level: 1
+      skill: Crafting/trained
+  Dubious Knowledge (Medicine):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Medicine
+    traits: []
+    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    prereq:
+      level: 1
+      skill: Medicine/trained
+  Dubious Knowledge (Nature):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits: []
+    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    prereq:
+      level: 1
+      skill: Nature/trained
+  Dubious Knowledge (Occultism):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    prereq:
+      level: 1
+      skill: Occultism/trained
+  Dubious Knowledge (Religion):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    prereq:
+      level: 1
+      skill: Religion/trained
+  Dubious Knowledge (Society):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    prereq:
+      level: 1
+      skill: Society/trained
+  Experienced Smuggler:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Stealth
+    traits: []
+    shortdesc: Conceal items from observers more effectively.
+    prereq:
+      level: 1
+      skill: Stealth/trained
+  Experienced Tracker:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: Track at your full Speed at a –5 penalty.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Express Rider:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits:
+    - exploration
+    - move
+    shortdesc: Increase your mount's travel speed.
+    prereq:
+      level: 1
+      skill: Nature/trained
+  Eye for Numbers:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: +2 to Decipher Writing about math and count items quickly.
+    prereq:
+      level: 1
+      skill: Society/trained
+  Fascinating Performance:
+    feat_type: 
+    - General
+    - Skill
+    assoc_skill: Performance
+    traits: []
+    shortdesc: Perform to fascinate observers.
+    prereq:
+      level: 1
+      skill: Performance/trained
+  Forager:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: Forage for supplies to provide for multiple creatures.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Forensic Acumen:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Medicine
+    traits: []
+    shortdesc: Rapidly examine a body and Recall Knowledge about it.
+    prereq:
+      level: 1
+      skill: Medicine/trained
+  Glean Contents:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: Decipher Writing even when you can’t see the document well.
+    prereq:
+      level: 1
+      skill: Society/trained
+  Group Coercion:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Intimidation
+    traits: []
+    shortdesc: Coerce multiple targets simultaneously.
+    prereq:
+      level: 1
+      skill: Intimidation/trained
+  Group Impression:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Diplomacy
+    traits: []
+    shortdesc: Make an Impression on multiple targets at once.
+    prereq:
+      level: 1
+      skill: Diplomacy/trained  
+  Hefty Hauler:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: Increase your Bulk limits by 2.
+    prereq:
+      level: 1
+      skill: Athletics/trained
+  Hobnobber:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Diplomacy
+    traits: []
+    shortdesc: Gather Information rapidly.
+    prereq:
+      level: 1
+      skill: Diplomacy/trained
+  Impressive Performance:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Performance
+    traits: []
+    shortdesc: Make an Impression with Performance.
+    prereq:
+      level: 1
+      skill: Performance/trained
   Improvise Tool:
     feat_type: 
     - Skill
@@ -225,6 +536,163 @@ pf2e_feats:
     prereq:
       level: 1
       skill: Crafting/trained
+  Inoculation:
+    feat_type: 
+    - General
+    - Skill
+    assoc_skill: Medicine
+    traits:
+    - healing
+    shortdesc: Grant patients +2 to saves against getting a disease again.
+    prereq:
+      level: 1
+      skill: Medicine/trained
+  Intimidating Glare:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Intimidation
+    traits: []
+    shortdesc: Demoralize a creature without speaking.
+    prereq:
+      level: 1
+      skill: Intimidation/trained
+  Lengthy Diversion:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Deception
+    traits: []
+    shortdesc: Remain hidden after you Create a Diversion.
+    prereq:
+      level: 1
+      skill: Deception/trained
+  Multilingual:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: Learn two new languages.
+    prereq:
+      level: 1
+      skill: Society/trained
+  Natural Medicine:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits: []
+    shortdesc: Use Nature to Treat Wounds.
+    prereq:
+      level: 1
+      skill: Nature/trained
+  No Cause for Alarm:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Diplomacy
+    traits:
+    - auditory
+    - concentrate
+    - emotion
+    - general
+    - linguistic
+    - mental
+    shortdesc: 'Reduce creatures’ frightened condition values.'
+    prereq:
+      level: 1
+      skill: Diplomacy/trained
+  Oddity Identification:
+    feat_type:
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: +2 to Occultism checks to Identify Magic with certain traits.
+    prereq:
+      level: 1
+      skill: Occultism/trained
+  Pickpocket:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Thievery
+    traits: []
+    shortdesc: Steal or Palm an Object more effectively.
+    prereq:
+      level: 1
+      skill: Thievery/trained
+  Pilgrim's Token:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: A religious token lets you act ﬁrst on a tie for initiative.
+    prereq:
+      level: 1
+      skill: Religion/trained
+  Quick Coercion:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Intimidation
+    traits: []
+    shortdesc: Coerce a creature quickly.
+    prereq:
+      level: 1
+      skill: Intimidation/trained
+  Quick Identification (Arcane):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Arcana
+    traits: []
+    shortdesc: Identify Magic in 1 minute or less.
+    prereq:
+      level: 1
+      skill: Arcana/trained
+  Quick Identification (Divine):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: Identify Magic in 1 minute or less.
+    prereq:
+      level: 1
+      skill: Religion/trained
+  Quick Identification (Occult):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: Identify Magic in 1 minute or less.
+    prereq:
+      level: 1
+      skill: Occultism/trained
+  Quick Identification (Primal):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits: []
+    shortdesc: Identify Magic in 1 minute or less.
+    prereq:
+      level: 1
+      skill: Nature/trained
+  Quick Jump:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: High Jump or Long Jump as a single action.
+    prereq:
+      level: 1
+      skill: Athletics/trained
   Quick Repair:
     feat_type: 
     - Skill
@@ -235,6 +703,97 @@ pf2e_feats:
     prereq:
       level: 1
       skill: Crafting/trained
+  Quick Squeeze:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Acrobatics
+    traits: []
+    shortdesc: Move swiftly as you Squeeze.
+    prereq:
+      level: 1
+      skill: Acrobatics/trained  
+  Read Lips:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: Read the lips of people you can see.
+    prereq:
+      level: 1
+      skill: Society/trained  
+  Recognize Spell (Arcane):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Arcana
+    traits: []
+    shortdesc: Identify a spell as a reaction as it's being cast.
+    prereq:
+      level: 1
+      skill: Arcana/trained
+  Recognize Spell (Divine):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: Identify a spell as a reaction as it's being cast.
+    prereq:
+      level: 1
+      skill: Religion/trained
+  Recognize Spell (Occult):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: Identify a spell as a reaction as it's being cast.
+    prereq:
+      level: 1
+      skill: Occultism/trained
+  Recognize Spell (Primal):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits:
+    - secret
+    shortdesc: Identify a spell as a reaction as it's being cast.
+    prereq:
+      level: 1
+      skill: Nature/trained
+  Risky Surgery:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Medicine
+    traits: []
+    shortdesc: Deal damage to a patient to gain +2 to Treat Wounds.
+    prereq:
+      level: 1
+      skill: Medicine/trained
+  Root Magic:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: Create a token that grants a bonus against a spell or haunt.
+    prereq:
+      level: 1
+      skill: Occultism/trained
+  Schooled in Secrets:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: Gather Information about secret societies and mystery cults.
+    prereq:
+      level: 1
+      skill: Occultism/trained
   Seasoned:
     feat_type: 
     - Skill
@@ -248,6 +807,15 @@ pf2e_feats:
       - Crafting/trained 
       - Alcohol Lore/trained 
       - Cooking Lore/trained
+  Skill Training:
+    feat_type: 
+    - General
+    - Skill
+    traits: []
+    shortdesc: Become trained in a skill.
+    prereq:
+      level: 1
+      ability: Intelligence/12
   Snare Crafting:
     feat_type: 
     - Skill
@@ -268,6 +836,301 @@ pf2e_feats:
     prereq:
       level: 1
       skill: Crafting/trained
+  Steady Balance:
+    feat_type:
+    - Skill
+    - General
+    assoc_skill: Acrobatics
+    traits: []
+    shortdesc: Maintain your balance in adverse conditions.
+    prereq:
+      level: 1
+      skill: Acrobatics/trained
+  Streetwise:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: Use Society to Gather Information and Recall Knowledge.
+    prereq:
+      level: 1
+      skill: Society/trained
+  Student of the Canon:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: More accurately recognize the tenets of your faith or philosophy.
+    prereq:
+      level: 1
+      skill: Religion/trained
+  Subtle Theft:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Thievery
+    traits: []
+    shortdesc: Your thefts are harder to notice.
+    prereq:
+      level: 1
+      skill: Thievery/trained
+  Survey Wildlife:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: Identify nearby creatures through signs and clues.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Terrain Expertise (Aquatic):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: +1 to Survival checks in certain terrain.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Terrain Expertise (Arctic):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: +1 to Survival checks in certain terrain.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Terrain Expertise (Desert):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: +1 to Survival checks in certain terrain.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Terrain Expertise (Forest):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: +1 to Survival checks in certain terrain.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Terrain Expertise (Mountain):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: +1 to Survival checks in certain terrain.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Terrain Expertise (Plains):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: +1 to Survival checks in certain terrain.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Terrain Expertise (Sky):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: +1 to Survival checks in certain terrain.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Terrain Expertise (Swamp):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: +1 to Survival checks in certain terrain.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Terrain Expertise (Underground):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: +1 to Survival checks in certain terrain.
+    prereq:
+      level: 1
+      skill: Survival/trained
+  Terrain Stalker:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Stealth
+    traits: []
+    shortdesc: Sneak in certain terrain without attempting a check.
+    prereq:
+      level: 1
+      skill: Stealth/trained
+  Titan Wrestler:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: Disarm, Grapple, Shove, or Trip larger creatures.
+    prereq:
+      level: 1
+      skill: Athletics/trained
+  Train Animal:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits:
+    - downtime
+    - manipulate
+    shortdesc: Teach an animal a trick.
+    prereq:
+      level: 1
+      skill: Nature/trained  
+  Trick Magic Item (Arcane):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Arcana
+    traits: []
+    shortdesc: Activate a magic item you normally can't activate.
+    prereq:
+      level: 1
+      skill: Arcana/trained
+  Trick Magic Item (Divine):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: Activate a magic item you normally can't activate.
+    prereq:
+      level: 1
+      skill: Religion/trained
+  Trick Magic Item (Occult):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occutltism
+    traits: []
+    shortdesc: Activate a magic item you normally can't activate.
+    prereq:
+      level: 1
+      skill: Occultism/trained
+  Trick Magic Item (Primal):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits: []
+    shortdesc: Activate a magic item you normally can't activate.
+    prereq:
+      level: 1
+      skill: Nature/trained
+  Underwater Marauder:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: Fight more effectively underwater.
+    prereq:
+      level: 1
+      skill: Athletics/trained
+  Virtuosic Performer:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Performance
+    traits: []
+    shortdesc: +1 with a certain type of performance.
+    prereq:
+      level: 1
+      skill: Performance/trained
+# Level 2 Feats
+  Armored Stealth:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Stealth
+    traits: []
+    shortdesc: Reduce the Stealth penalty of your armor.
+    prereq:
+      level: 2
+      skill: Stealth/expert
+  Assured Identification (Arcane):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Arcana
+    traits: []
+    shortdesc: Avoid misidentifying magic.
+    prereq:
+      level: 2
+      skill: Arcana/expert
+  Assured Identification (Divine):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: Avoid misidentifying magic.
+    prereq:
+      level: 2
+      skill: Divine/expert
+  Assured Identification (Primal):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits: []
+    shortdesc: Avoid misidentifying magic.
+    prereq:
+      level: 2
+      skill: Nature/expert
+  Assured Identification (Occult):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: Avoid misidentifying magic.
+    prereq:
+      level: 2
+      skill: Occult/expert
+  Automatic Knowledge (Arcana):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Arcana
+    traits: []
+    shortdesc: Recall Knowledge as a free action once per round.
+    prereq:
+      level: 2
+      skill: Arcana/expert
+      feat:
+      - Assurance (Arcana)      
   Automatic Knowledge (Crafting):
     feat_type: 
     - Skill
@@ -278,37 +1141,91 @@ pf2e_feats:
     prereq:
       level: 2
       skill: Crafting/expert
-  Magical Crafting:
+      feat:
+      - Assurance (Crafting)
+  Automatic Knowledge (Medicine):
     feat_type: 
     - Skill
     - General
-    assoc_skill: Crafting
+    assoc_skill: Medicine
     traits: []
-    shortdesc: Craft magic items.
+    shortdesc: Recall Knowledge as a free action once per round.
     prereq:
       level: 2
-      skill: Crafting/expert
-  Assurance (Deception):
+      skill: Medicine/expert
+      feat:
+      - Assurance (Medicine)
+  Automatic Knowledge (Nature):
     feat_type: 
-    - General
     - Skill
-    assoc_skill: Deception
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Deception/trained
-  Charming Liar:
-    feat_type: 
     - General
-    - Skill
-    assoc_skill: Deception
+    assoc_skill: Nature
     traits: []
-    shortdesc: Improve a target's attitude with your lies.
+    shortdesc: Recall Knowledge as a free action once per round.
     prereq:
-      level: 1
-      skill: Deception/trained
+      level: 2
+      skill: Nature/expert
+      feat:
+      - Assurance (Nature)
+  Automatic Knowledge (Occultism):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: Recall Knowledge as a free action once per round.
+    prereq:
+      level: 2
+      skill: Occultism/expert
+      feat:
+      - Assurance (Occultism)
+  Automatic Knowledge (Religion):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: Recall Knowledge as a free action once per round.
+    prereq:
+      level: 2
+      skill: Religion/expert
+      feat:
+      - Assurance (Crafting)
+  Automatic Knowledge (Society):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: Recall Knowledge as a free action once per round.
+    prereq:
+      level: 2
+      skill: Society/expert
+      feat:
+      - Assurance (Society)
+  Battle Planner:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Warfare Lore
+    traits:
+    - general
+    - skill
+    shortdesc: Make a battle plan and roll Warfare Lore for initiative.
+    prereq:
+      level: 2
+      skill: Warfare Lore/expert
+  Bonded Animal:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits:
+    - downtime
+    shortdesc: An animal becomes permanently helpful to you.
+    prereq:
+      level: 2
+      skill: Nature/expert
   Confabulator:
     feat_type: 
     - General
@@ -318,8 +1235,44 @@ pf2e_feats:
     shortdesc: Reduce the bonuses against your repeated lies.
     prereq:
       level: 2
-      skill: Deception/expert
-  Discreet Inquiry:
+      skill: Deception/expert  
+  Connections:
+    feat_type: 
+    - General
+    - Skill
+    assoc_skill: Society
+    traits: []
+    shortdesc: Leverage your connections for favors and meetings.
+    prereq:
+      level: 2
+      skill: Society/expert
+      feat:
+      - Courtly Graces
+    uncommon: true
+  Continual Recovery:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Medicine
+    traits: []
+    shortdesc: Treat Wounds on a patient more often.
+    prereq:
+      level: 2
+      skill: Medicine/expert
+  Criminal Connections:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: Leverage your underworld connections for favors from criminals.
+    prereq:
+      level: 2
+      skill: Society/expert
+      feat:
+      - Streetwise
+    uncommon: true
+  Discreet Inquiry (Deception):
     feat_type: 
     - General
     - Skill
@@ -331,79 +1284,7 @@ pf2e_feats:
       orskill: 
       - Deception/expert 
       - Diplomacy/expert
-  Assurance (Diplomacy):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Diplomacy
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Diplomacy/trained
-  Bargain Hunter:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Diplomacy
-    traits: []
-    shortdesc: Earn Income by searching for deals.
-    prereq:
-      level: 1
-      skill: Diplomacy/trained
-  Bon Mot:
-    feat_type: 
-    - Skill
-    assoc_skill: Diplomacy
-    traits:
-    - auditory
-    - concentrate
-    - emotion
-    - general
-    - linguistic
-    - mental
-    shortdesc: Distract a foe with a witty quip.
-    prereq:
-      level: 1
-      skill: Diplomacy/trained
-  Group Impression:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Diplomacy
-    traits: []
-    shortdesc: Make an Impression on multiple targets at once.
-    prereq:
-      level: 1
-      skill: Diplomacy/trained
-  Hobnobber:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Diplomacy
-    traits: []
-    shortdesc: Gather Information rapidly.
-    prereq:
-      level: 1
-      skill: Diplomacy/trained
-  No Cause for Alarm:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Diplomacy
-    traits:
-    - auditory
-    - concentrate
-    - emotion
-    - general
-    - linguistic
-    - mental
-    shortdesc: 'Reduce creatures’ frightened condition values.'
-    prereq:
-      level: 1
-      skill: Diplomacy/trained
-  Discreet Inquiry:
+  Discreet Inquiry (Diplomacy):
     feat_type: 
     - Skill
     - General
@@ -415,6 +1296,26 @@ pf2e_feats:
       orskill: 
       - Diplomacy/expert 
       - Deception/expert
+  Distracting Performance:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Performance
+    traits: []
+    shortdesc: Create a Diversion for an ally.
+    prereq:
+      level: 2
+      skill: Performance/expert
+  Exhort the Faithful:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: +2 to Request something of or Coerce members of your own faith.
+    prereq:
+      level: 2
+      skill: Religion/expert  
   Glad-Hand:
     feat_type: 
     - Skill
@@ -425,47 +1326,6 @@ pf2e_feats:
     prereq:
       level: 2
       skill: diplomacy/expert
-  Assurance (Intimidation):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Intimidation
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Intimidation/trained
-  Group Coercion:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Intimidation
-    traits: []
-    shortdesc: Coerce multiple targets simultaneously.
-    prereq:
-      level: 1
-      skill: Intimidation/trained
-  Intimidating Glare:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Intimidation
-    traits: []
-    shortdesc: Demoralize a creature without speaking.
-    prereq:
-      level: 1
-      skill: Intimidation/trained
-  Quick Coercion:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Intimidation
-    traits: []
-    shortdesc: Coerce a creature quickly.
-    prereq:
-      level: 1
-      skill: Intimidation/trained
   Intimidating Prowess:
     feat_type: 
     - Skill
@@ -487,469 +1347,36 @@ pf2e_feats:
     prereq:
       level: 2
       skill: Intimidation/expert
-  Terrifying Resistance:
+  Lead Climber:
     feat_type: 
     - Skill
     - General
-    assoc_skill: Intimidation
+    assoc_skill: Athletics
     traits: []
-    shortdesc: +1 to spell saves from a creature you've Demoralized.
+    shortdesc: Make Climbing safer for allies who Follow the Expert.
     prereq:
       level: 2
-      skill: Intimidation/expert
-  Additional Lore:
+      skill: Athletics/expert
+  Magical Crafting:
     feat_type: 
     - Skill
     - General
-    assoc_skill: Lore
+    assoc_skill: Crafting
     traits: []
-    shortdesc: Become trained in another Lore subcategory.
-    prereq:
-      level: 1
-      skill: Lore/trained
-  Assurance (Lore):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Lore
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Lore/trained
-  Automatic Knowledge (Lore):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Lore
-    traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
+    shortdesc: Craft magic items.
     prereq:
       level: 2
-      skill: Lore/expert
-  Battle Planner:
+      skill: Crafting/expert
+  Magical Shorthand (Arcane):
     feat_type: 
     - Skill
     - General
-    assoc_skill: Warfare Lore
-    traits:
-    - general
-    - skill
-    shortdesc: Make a battle plan and roll Warfare Lore for initiative.
-    prereq:
-      level: 2
-      skill: Warfare Lore/expert
-  Unmistakable Lore:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Lore
-    traits: []
-    shortdesc: FIND MY FUCKING SHORTDESC ALREADY
-    prereq:
-      level: 2
-      skill: Lore/expert
-  Assurance (Medicine):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Medicine
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Medicine/trained
-  Battle Medicine:
-    feat_type: 
-    - General
-    - Skill
-    assoc_skill: Medicine
-    traits:
-    - healing
-    - manipulate
-    shortdesc: Heal yourself or an ally in battle.
-    prereq:
-      level: 1
-      skill: Medicine/trained
-  Forensic Acumen:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Medicine
-    traits: []
-    shortdesc: Rapidly examine a body and Recall Knowledge about it.
-    prereq:
-      level: 1
-      skill: Medicine/trained
-  Inoculation:
-    feat_type: 
-    - General
-    - Skill
-    assoc_skill: Medicine
-    traits:
-    - healing
-    shortdesc: Grant patients +2 to saves against getting a disease again.
-    prereq:
-      level: 1
-      skill: Medicine/trained
-  Risky Surgery:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Medicine
-    traits: []
-    shortdesc: Deal damage toa patient to gain +2 to Treat Wounds.
-    prereq:
-      level: 1
-      skill: Medicine/trained
-  Automatic Knowledge (Medicine):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Medicine
-    traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
-    prereq:
-      level: 2
-      skill: Medicine/expert
-  Continual Recovery:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Medicine
-    traits: []
-    shortdesc: Treat Wounds on a patient more often.
-    prereq:
-      level: 2
-      skill: Medicine/expert
-  Robust Recovery:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Medicine
-    traits: []
-    shortdesc: Greater benefits from Treat Disease and Treat Poison.
-    prereq:
-      level: 2
-      skill: Medicine/expert
-  Ward Medic:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Medicine
-    traits: []
-    shortdesc: Treat several patients at once.
-    prereq:
-      level: 2
-      skill: Medicine/expert
-  Assurance (Nature):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Nature/trained
-  Express Rider:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
-    traits:
-    - exploration
-    - move
-    shortdesc: Increase your mount's travel speed.
-    prereq:
-      level: 1
-      skill: Nature/trained
-  Natural Medicine:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
-    traits: []
-    shortdesc: Use Nature to Treat Wounds.
-    prereq:
-      level: 1
-      skill: Nature/trained
-  Quick Identification (Primal):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
-    traits: []
-    shortdesc: Identify magic in 1 minute or less.
-    prereq:
-      level: 1
-      skill: Nature/trained
-  Recognize Spell (Primal):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
-    traits:
-    - secret
-    shortdesc: Identify a spell as a reacting as it's being cast.
-    prereq:
-      level: 1
-      skill: Nature/trained
-  Train Animal:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
-    traits:
-    - downtime
-    - manipulate
-    shortdesc: Teach an animal a trick.
-    prereq:
-      level: 1
-      skill: Nature/trained
-  Trick Magic Item (Primal):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
-    traits: []
-    shortdesc: Activate a magic item you normally can't activate.
-    prereq:
-      level: 1
-      skill: Nature/trained
-  Assured Identification (Primal):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
-    traits: []
-    shortdesc: Avoid misidentifying magic.
-    prereq:
-      level: 2
-      skill: Nature/expert
-  Automatic Knowledge (Nature):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
-    traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
-    prereq:
-      level: 2
-      skill: Nature/expert
-  Bonded Animal:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
-    traits:
-    - downtime
-    shortdesc: An animal becomes permanently helpful to you.
-    prereq:
-      level: 2
-      skill: Nature/expert
-  Magical Shorthand (Primal):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Nature
+    assoc_skill: Arcana
     traits: []
     shortdesc: Learn spells quickly and at a reduced cost.
     prereq:
       level: 2
-      skill: Nature/expert
-  Assurance (Occultism):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Occultism
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Occultism/trained
-  Deceptive Worship:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Occultism
-    traits: []
-    shortdesc: Pass yourself off as a member of a religion.
-    prereq:
-      level: 1
-      skill: Occultism/trained
-  Assured Identification (Occult):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Occultism
-    traits: []
-    shortdesc: Avoid misidentifying magic.
-    prereq:
-      level: 2
-  Automatic Knowledge (Occultism):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Occultism
-    traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
-    prereq:
-      level: 2
-  Magical Shorthand (Occult):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Occultism
-    traits: []
-    shortdesc: Learn spells quickly and at a reduced cost.
-    prereq:
-      level: 2
-      skill: Occultism/expert
-  Assurance (Performance):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Performance
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Performance/trained
-  Fascinating Performance:
-    feat_type: 
-    - General
-    - Skill
-    assoc_skill: Performance
-    traits: []
-    shortdesc: Perform to fascinate observers.
-    prereq:
-      level: 1
-      skill: Performance/trained
-  Impressive Performance:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Performance
-    traits: []
-    shortdesc: Make an Impression with Performance.
-    prereq:
-      level: 1
-      skill: Performance/trained
-  Virtuosic Performer:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Performance
-    traits: []
-    shortdesc: +1 with a certain type of performance.
-    prereq:
-      level: 1
-      skill: Performance/trained
-  Distracting Performance:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Performance
-    traits: []
-    shortdesc: Create a Diversion for an ally.
-    prereq:
-      level: 2
-      skill: Performance/expert
-  Assurance (Religion):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Religion
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Religion/trained
-  Pilgrim's Token:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Religion
-    traits: []
-    shortdesc: A religious token lets you act ﬁrst on a tie for initiative.
-    prereq:
-      level: 1
-      skill: Religion/trained
-  Quick Identification (Divine):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Religion
-    traits: []
-    shortdesc: Identify Magic in 1 minute or less.
-    prereq:
-      level: 1
-      skill: Religion/trained
-  Recognize Spell (Divine):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Religion
-    traits: []
-    shortdesc: Identify a spell as a reaction as it's being cast.
-    prereq:
-      level: 1
-      skill: Religion/trained
-  Student of the Canon:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Religion
-    traits: []
-    shortdesc: More accurately recognize the tenets of your faith or philosophy.
-    prereq:
-      level: 1
-      skill: Religion/trained
-  Trick Magic Item (Divine):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Religion
-    traits: []
-    shortdesc: Activate a magic item you normally can't activate.
-    prereq:
-      level: 1
-      skill: Religion/trained
-  Assured Identification (Divine):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Religion
-    traits: []
-    shortdesc: Avoid misidentifying magic.
-    prereq:
-      level: 2
-  Automatic Knowledge (Religion):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Religion
-    traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
-    prereq:
-      level: 2
-  Exhort the Faithful:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Religion
-    traits: []
-    shortdesc: +2 to Request something of or Coerce members of your own faith.
-    prereq:
-      level: 2
-      skill: Religion/expert
+      skill: Arcana/expert
   Magical Shorthand (Divine):
     feat_type: 
     - Skill
@@ -960,120 +1387,46 @@ pf2e_feats:
     prereq:
       level: 2
       skill: Religion/expert
-  Assurance (Society):
+  Magical Shorthand (Occult):
     feat_type: 
     - Skill
     - General
-    assoc_skill: Society
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Society/trained
-  Courtly Graces:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Society
+    assoc_skill: Occultism
     traits: []
-    shortdesc: Use Society to get along in noble society.
-    prereq:
-      level: 1
-      skill: Society/trained
-  Eye for Numbers:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Society
-    traits: []
-    shortdesc: +2 to Decipher Writing about math and count items quickly.
-    prereq:
-      level: 1
-      skill: Society/trained
-  Glean Contents:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Society
-    traits: []
-    shortdesc: Decipher Writing even when you can’t see the document well.
-    prereq:
-      level: 1
-      skill: Society/trained
-  Multilingual:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Society
-    traits: []
-    shortdesc: Learn two new languages.
-    prereq:
-      level: 1
-      skill: Society/trained
-  Read Lips:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Society
-    traits: []
-    shortdesc: Read the lips of people you can see.
-    prereq:
-      level: 1
-      skill: Society/trained
-  Sign Language:
-    feat_type: 
-    - General
-    - Skill
-    assoc_skill: Society
-    traits: []
-    shortdesc: Learn sign languages.
-    prereq:
-      level: 1
-      skill: Society/trained
-  Streetwise:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Society
-    traits: []
-    shortdesc: Use Society to Gather Information and Recall Knowledge.
-    prereq:
-      level: 1
-      skill: Society/trained
-  Automatic Knowledge (Society):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Society
-    traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
+    shortdesc: Learn spells quickly and at a reduced cost.
     prereq:
       level: 2
-  Connections:
-    feat_type: 
-    - General
-    - Skill
-    assoc_skill: Society
-    traits: []
-    shortdesc: Leverage your connections for favors and meetings.
-    prereq:
-      level: 2
-      skill: Society/expert
-      feat: 
-      - Courtly Graces
-  Criminal Connections:
+      skill: Occultism/expert  
+  Magical Shorthand (Primal):
     feat_type: 
     - Skill
     - General
-    assoc_skill: Society
+    assoc_skill: Nature
     traits: []
-    shortdesc: Leverage your underworld connections for favors from criminals.
+    shortdesc: Learn spells quickly and at a reduced cost.
     prereq:
       level: 2
-      skill: Society/expert
-      feat: 
-      - Streetwise
+      skill: Nature/expert
+  Nimble Crawl:
+    feat_type:
+    - Skill
+    - General
+    assoc_skill: Acrobatics
+    traits: []
+    shortdesc: Crawl at a faster rate.
+    prereq: 
+      level: 2
+      skill: Acrobatics/expert
+  Powerful Leap:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: Jump farther and higher.
+    prereq:
+      level: 2
+      skill: Athletics/expert
   Quick Contacts:
     feat_type: 
     - Skill
@@ -1084,62 +1437,19 @@ pf2e_feats:
     prereq:
       level: 2
       skill: Society/expert
-      orfeat: 
+      orfeat:
       - Connections 
       - Criminal Connections
-  Underground Network:
-    feat_type: 
-    - General
+  Quick Disguise:
+    feat_type:
     - Skill
-    assoc_skill: Society
+    - General
+    assoc_skill: Deception
     traits: []
-    shortdesc: Gather Information without drawing attention and gain a bonus to Recall Knowledge about that subject.
+    shortdesc: Set up a disguise in only half the time.
     prereq:
       level: 2
-      skill: Society/expert
-      feat: 
-      - Streetwise
-  Assurance (Stealth):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Stealth
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Stealth/trained
-  Experienced Smuggler:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Stealth
-    traits: []
-    shortdesc: Conceal items from observers more effectively.
-    prereq:
-      level: 1
-      skill: Stealth/trained
-  Terrain Stalker:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Stealth
-    traits: []
-    shortdesc: Sneak in certain terrain without attempting a check.
-    prereq:
-      level: 1
-      skill: Stealth/trained
-  Armored Stealth:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Stealth
-    traits: []
-    shortdesc: Reduce the Stealth penalty of your armor.
-    prereq:
-      level: 2
-      skill: Stealth/expert
+      skill: Deception/expert
   Quiet Allies:
     feat_type: 
     - Skill
@@ -1150,6 +1460,26 @@ pf2e_feats:
     prereq:
       level: 2
       skill: Stealth/expert
+  Rapid Mantel:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: Pull yourself onto ledges quickly.
+    prereq:
+      level: 2
+      skill: Athletics/expert
+  Robust Recovery:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Medicine
+    traits: []
+    shortdesc: Greater benefits from Treat Disease and Treat Poison.
+    prereq:
+      level: 2
+      skill: Medicine/expert
   Shadow Mark:
     feat_type: 
     - Skill
@@ -1160,98 +1490,47 @@ pf2e_feats:
     prereq:
       level: 2
       skill: Stealth/expert
-  Assurance (Survival):
+  Terrifying Resistance:
     feat_type: 
     - Skill
     - General
-    assoc_skill: Survival
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Survival/trained
-  Experienced Tracker:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Survival
+    assoc_skill: Intimidation
     traits: []
-    shortdesc: Track at your full Speed at a –5 penalty.
+    shortdesc: +1 to spell saves from a creature you've Demoralized.
     prereq:
-      level: 1
-      skill: Survival/trained
-  Forager:
+      level: 2
+      skill: Intimidation/expert
+  Underground Network:
     feat_type: 
-    - Skill
     - General
-    assoc_skill: Survival
+    - Skill
+    assoc_skill: Society
     traits: []
-    shortdesc: Forage for supplies to provide for multiple creatures.
+    shortdesc: Gather Information without drawing attention and gain a bonus to Recall Knowledge about that subject.
     prereq:
-      level: 1
-      skill: Survival/trained
-  Survey Wildlife:
-    feat_type: 
-    - Skill
+      level: 2
+      skill: Society/expert
+      feat:
+      - Streetwise
+    uncommon: true
+  Unmistakable Lore:
+    feat_type:
     - General
-    assoc_skill: Survival
+    - Skill
     traits: []
-    shortdesc: Identify nearby creatures through signs and clues.
+    shortdesc: Recall Knowledge about your Lore more effectively.
     prereq:
-      level: 1
-      skill: Survival/trained
-  Terrain Expertise:
+      level: 2
+  Ward Medic:
     feat_type: 
     - Skill
     - General
-    assoc_skill: Survival
+    assoc_skill: Medicine
     traits: []
-    shortdesc: +1 to Survival checks in certain terrain.
+    shortdesc: Treat several patients at once.
     prereq:
-      level: 1
-      skill: Survival/trained
-  Assurance (Thievery):
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Thievery
-    traits:
-    - fortune
-    shortdesc: Receive a fixed result on a skill check.
-    prereq:
-      level: 1
-      skill: Thievery/trained
-  Concealing Legerdemain:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Thievery
-    traits: []
-    shortdesc: Conceal an Object using Thievery instead of Stealth.
-    prereq:
-      level: 1
-      skill: Thievery/trained
-  Pickpocket:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Thievery
-    traits: []
-    shortdesc: Steal or Palm an Object more effectively.
-    prereq:
-      level: 1
-      skill: Thievery/trained
-  Subtle Theft:
-    feat_type: 
-    - Skill
-    - General
-    assoc_skill: Thievery
-    traits: []
-    shortdesc: Your thefts are harder to notice.
-    prereq:
-      level: 1
-      skill: Thievery/trained
+      level: 2
+      skill: Medicine/expert
   Wary Disarmament:
     feat_type: 
     - Skill
@@ -1260,5 +1539,5 @@ pf2e_feats:
     traits: []
     shortdesc: +2 to AC or saves against devices or traps you trigger while disarming.
     prereq:
-      level: 1
+      level: 2
       skill: Thievery/expert

--- a/game/config/pf2e_skills.yml
+++ b/game/config/pf2e_skills.yml
@@ -39,7 +39,7 @@ pf2e_skills:
     key_abil: Wisdom
   Thievery:
     key_abil: Dexterity
-
+# Deity Lores
   Althean Lore: 
     key_abil: Intelligence
     recall_knowledge: true
@@ -103,7 +103,8 @@ pf2e_skills:
   Thulite Lore: 
     key_abil: Intelligence
     recall_knowledge: true
-  Alexandrian Lore: 
+# City Lores
+  Alexandria Lore: 
     key_abil: Intelligence
     recall_knowledge: true
   Bryn Myridorn Lore: 
@@ -121,28 +122,91 @@ pf2e_skills:
   Vandalheim Lore: 
     key_abil: Intelligence
     recall_knowledge: true
-  Cave Lore: 
+# Region Lores
+  Alexandros Lore: 
     key_abil: Intelligence
     recall_knowledge: true
-  Desert Lore: 
+  Am'shere Lore:
     key_abil: Intelligence
     recall_knowledge: true
-  Plains Lore: 
+  Bludgun Lore: 
     key_abil: Intelligence
     recall_knowledge: true
-  Swamp Lore: 
+  Charn Lore: 
     key_abil: Intelligence
     recall_knowledge: true
-  Winterland Lore: 
+  Dragonier Lore:
     key_abil: Intelligence
     recall_knowledge: true
-  Mountains Lore: 
+  Dran Lore: 
     key_abil: Intelligence
     recall_knowledge: true
-  Hills Lore: 
+  Desolation Lore:
     key_abil: Intelligence
     recall_knowledge: true
-  Island Lore: 
+  Greatwoods Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Jade Islands Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Khazad Duin Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Myrddion Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Rune Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Sturmvargd Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Vast Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Veyshan Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+# Terrain Lores
+  Aquatic Terrain Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Arctic Terrain Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Desert Terrain Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+  Forest Terrain Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+  Mountain Terrain Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+  Plains Terrain Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+  Sky Terrain Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+  Swamp Terrain Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+  Underground Terrain Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+# Creature Lores
+  Angel Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Azata Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Beast Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Daemon Lore:
     key_abil: Intelligence
     recall_knowledge: true
   Demon Lore: 
@@ -151,13 +215,99 @@ pf2e_skills:
   Devil Lore: 
     key_abil: Intelligence
     recall_knowledge: true
+  Dragon Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Fey Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+  Fey Bullshit Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+  Genie Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Giant Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Hag Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Qlippoth Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Rakshasa Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Serpentfolk Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Spirit Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
   Vampire Lore: 
     key_abil: Intelligence
     recall_knowledge: true
+  Velstrac Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+# PC Ancestry and Heritage Lores
+  Aesa Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Arvek Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Ashen One Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Bassin Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Changeling Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Ciith Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Dar Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Egalrin Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Gnome Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Goblin Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Human Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Kailli Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Khazad Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Niasa Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Oruch Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Sildanyar Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+# General/Profession Lores
   Academia Lore: 
     key_abil: Intelligence
     recall_knowledge: true
   Accounting Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+  Alcohol Lore: 
     key_abil: Intelligence
     recall_knowledge: true
   Architecture Lore: 
@@ -166,19 +316,19 @@ pf2e_skills:
   Art Lore: 
     key_abil: Intelligence
     recall_knowledge: true
+  Cartography Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
   Circus Lore: 
     key_abil: Intelligence
     recall_knowledge: true
-  Engineering Lore: 
+  Curse Lore:
+    key_abil: Intelligence
+    recall_knowledge: true
+  Engineering Lore:
     key_abil: Intelligence
     recall_knowledge: true
   Farming Lore: 
-    key_abil: Intelligence
-    recall_knowledge: true
-  Fey Lore: 
-    key_abil: Intelligence
-    recall_knowledge: true
-  Fey Bullshit Lore:
     key_abil: Intelligence
     recall_knowledge: true
   Fishing Lore: 
@@ -197,6 +347,9 @@ pf2e_skills:
     key_abil: Intelligence
     recall_knowledge: true
   Guild Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
+  Great Halls Lore:
     key_abil: Intelligence
     recall_knowledge: true
   Heraldry Lore: 
@@ -235,10 +388,7 @@ pf2e_skills:
   Scouting Lore: 
     key_abil: Intelligence
     recall_knowledge: true
-  Scribing Lore: 
-    key_abil: Intelligence
-    recall_knowledge: true
-  Tanning Lore: 
+  Slayer Lore: 
     key_abil: Intelligence
     recall_knowledge: true
   Theater Lore: 
@@ -250,6 +400,7 @@ pf2e_skills:
   Warfare Lore: 
     key_abil: Intelligence
     recall_knowledge: true
+# Crafting Lores
   Alchemy Lore: 
     key_abil: Intelligence
     recall_knowledge: true
@@ -271,6 +422,9 @@ pf2e_skills:
   Pottery Lore: 
     key_abil: Intelligence
     recall_knowledge: true
+  Scribing Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
   Shipbuilding Lore: 
     key_abil: Intelligence
     recall_knowledge: true
@@ -280,12 +434,16 @@ pf2e_skills:
   Tailoring Lore: 
     key_abil: Intelligence
     recall_knowledge: true
+  Tanning Lore: 
+    key_abil: Intelligence
+    recall_knowledge: true
   Weaving Lore: 
     key_abil: Intelligence
     recall_knowledge: true
   Woodworking Lore: 
     key_abil: Intelligence
     recall_knowledge: true
-  Slayer Lore: 
+# Special/Class Specific Lores
+  Bardic Lore:
     key_abil: Intelligence
     recall_knowledge: true


### PR DESCRIPTION
Multiple YML files edited and corrected. Changelog is as follows:

## All files
Improved structure by adding comments where applicable. Should be much easier to navigate around in them now.

## pf2_feat_ancestry
Edited for themely adhesion/removal of sources not permitted in game.

### Arvek
Arvek feats not from the Character Guide:
**Level 1**
- Sneaky
- Stone Face
**Level 5**
- Recognize Ambush
- Runtsage
**Level 17**
- Azaersi's Roads
### Bassin
Bassin heritages not from the CRB/APG:
- Observant
Bassin feats not from the CRB/APG:
**Level 9**
- Cunning Climber
- Fade Away
- Helpful Bassin
**Level 13**
- Cobble Dancer
- "Incredible Luck (Bassin)"
### Ciith
Renamed Sith-makar heritage to Makar.
Ciith feats not from the Character Guide:
**Level 5**
- Fey Influence
**Level 13**
- Ciith Unarmed Expertise
### Egalrin
Egalrin feats not from the CRB/APG:
**Level 1**
- "Mariner's Fire"
- Uncanny Agility
- Waxed Feathers
**Level 5**
- Dogfang Bite
- Egalrin Feather Fan
- Magpie Snatch
### Gnome
Gnome heritages not from the CRB/APG:
- Vivacious
Gnome feats not from the CRB/APG:
**Level 1**
- Gnome Polyglot
- Grim Insight
- Inventive Offensive
- Life-Giving Magic
- Natural Performer
- Theoretical Acumen
- Unexpected Shift
- Vibrant Display
**Level 5**
- Intuitive Illusions
- Natural Illusionist
**Level 9**
- Fortuitous Shift
### Goblin
Goblin heritages not from the CRB/APG:
- Tailed
- Treedweller
Goblin feats not from the CRB/APG:
**Level 1**
- Bouncy Goblin
- Fang Sharpener
- Hard Tail
**Level 5**
- Ankle Bite
- Tail Spin
- Torch Goblin
- "Tree Climber (Goblin)"
**Level 9**
- Freeze It!
- Hungry Goblin
- Roll With It
- Scalding Spit
**Level 13**
- Unbreakable-er Goblin
### Human
Human heritages not from the CRB/APG:
- Wintertouched
Human feats not from the CRB/APG:
**Level 1**
- Arcane Tattoos
- Gloomseer
**Level 9**
- Dragon Prince
- Heir of the Saoc
- Shory Aeromancer
- Virtue-Forged Tattoos
**Level 13**
- Irriseni Ice-Witch
- Shadow Pact
### Kailli
Kailli heritages not from the CRB/APG:
- Snow Rat
- Tunnel Rat
Kailli feats not from the CRB/APG:
**Level 5**
- Gnaw
- Kailli Roll
- Plague Sniffer
**Level 13**
- Shinstabber
- Skittering Sneak
- Kailli Growth
### Khazad
Khazad heritages not from the CRB/APG:
- Elemental Heart
- Oathkeeper
Khazad feats not from the CRB/APG:
**Level 5**
- "Tomb-Watcher's Glare"
**Level 9**
- Battleforger
- Energy Blessed
- "Heroes' Call"
- Kneel for No God
### Oruch
Fixing of ability boosts and flaw code, all feats and heritages validated.
### Sildanyar
Various feats renamed for themely adhesion.
Sildanyar heritages not from the CRB/APG:
- Ancient
- Desert
Sildanyar feats not from the CRB/APG:
**Level 1**
- Share Thoughts
**Level 9**
- Brightness Seeker
- Sense Thoughts
**Level 13**
- Wandering Heart

## pf2e_armor
Data entry errors corrected.

## pf2e_background
Backgrounds removed that were not from the CRB/APG:
- Harrow-led
Backgrounds removed because they would balloon YML structure:
- Hermit
Edited multiple backgrounds to fit current YML structure.

## pf2e_feat_ancestry
Deleted data for feats removed in pf2e_ancestry.
Added `init_magic: true` to some feats that needed it.

## pf2e_feat_class
Data entry errors corrected.
Added `init_magic: true` to some feats that needed it.

## pf2e_feat_general
Data entry errors corrected. 
Moved Skill Training feat to pf2e_feat_skill

## pf2e_feat_skill
Data entry errors corrected.
Edited multiple feats to fit current YML structure.

## pf2e_skills
Massive structural overhaul. Added many Lore skills.