### PR TITLE
boost type error fix in cg/review

### DIFF
--- a/plugins/pf2e/models/abilities.rb
+++ b/plugins/pf2e/models/abilities.rb
@@ -59,6 +59,11 @@ module AresMUSH
       a = []
       boosts.each_pair do |k,v|
         free_unassigned = v.include?("open")
+
+        # Next code block is expected an array, but charclass key_ability can sometimes 
+        # be a string. A one-time recast seems most eligant
+        v = v.is_a?(String) ? v = Array(v) : v
+ 
         choice_not_made = v.any? { |v| v.is_a?(Array) }
 
         a << k if free_unassigned || choice_not_made


### PR DESCRIPTION
%% Sorry! The code lost its mind while executing a command.  Not your fault.
Please send this error information to the admins and tell them what you were doing at the time:
Description: "cg/review"
Error: "undefined method `any?' for "Intelligence":String

        choice_not_made = v.any? { |v| v.is_a?(Array) }
                           ^^^^^"

As the code was looping through the array, it encountered a string, which doesn't have an any? method. To avoid conflicts with other areas of the code which might expect a string, I recast any string that comes through as a single value hash