### PR TITLE
Magic helpfile and cantrip cleanup.

### DIFF
--- a/game/config/pf2e_spells_a-e.yml
+++ b/game/config/pf2e_spells_a-e.yml
@@ -292,7 +292,7 @@ pf2e_spells:
     heighten:
       3: You can specify criteria for which creatures sound the alarm spell — for instance, orcs or masked people.
   Allegro:
-    base_level: 7
+    base_level: cantrip
     school: Enchantment
     traits:
     - bard
@@ -1829,7 +1829,7 @@ pf2e_spells:
     duration: 10 minutes
     effect: You create an invisible floating eye at a location within range (even if it's outside your line of sight or line of effect). The eye can't move, but you can see in all directions from that point as if using your normal visual senses.
   Clinging Ice:
-    base_level: 1
+    base_level: cantrip
     school: Conjuration
     traits:
     - cantrip
@@ -3031,7 +3031,7 @@ pf2e_spells:
       5: Your battle form is Huge and your attacks have 15-foot reach, or 20-foot reach if they started with 15-foot reach. You instead gain 20 temporary HP, an attack modifier of +18, a damage bonus of +6, double the damage dice, and Athletics +21.
       7: Your battle form is Huge and your attacks have 15-foot reach, or 20-foot reach if they started with 15-foot reach. You instead gain 20 temporary HP, an attack modifier of +18, a damage bonus of +6, double the damage dice, and Athletics +21.
   Dirge of Doom:
-    base_level: 3
+    base_level: cantrip
     school: Enchantment
     traits:
     - bard
@@ -3104,7 +3104,7 @@ pf2e_spells:
     target: 1 creature or object
     effect: You learn the name of the target's exact location (including the building, community, and country) and plane of existence.%r%rYou can target a creature only if you've seen it in person, have one of its significant belongings, or have a piece of its body. To target an object, you must have touched it or have a fragment of it. *Discern location* automatically overcomes protections against detection and divination of lower level than this spell, even if they would normally have a chance to block it.
   Discern Secrets:
-    base_level: 1
+    base_level: cantrip
     school: Divination
     traits:
     - cantrip
@@ -4362,7 +4362,7 @@ pf2e_spells:
     heighten:
       9: You can target up to five additional willing creatures at a range of 30 feet. The duration is up to 10 minutes.
   Evil Eye:
-    base_level: 1
+    base_level: cantrip
     school: Enchantment
     traits:
     - cantrip

--- a/game/config/pf2e_spells_f-j.yml
+++ b/game/config/pf2e_spells_f-j.yml
@@ -634,7 +634,7 @@ pf2e_spells:
     heighten:
       8: The bonus increases by 1.
   Forbidding Ward:
-    base_level: 1
+    base_level: cantrip
     school: Abjuration
     traits:
     - abjuration
@@ -1186,7 +1186,7 @@ pf2e_spells:
     cast:
     - verbal
     effect: You ask for divine guidance, granting the target a +1 status bonus to one attack roll, Perception check, saving throw, or skill check the target attempts before the duration ends. The target chooses which roll to use the bonus on before rolling. If the target uses the bonus, the spell ends. Either way, the target is then temporarily immune for 1 hour.
-    base_level: 1
+    base_level: cantrip
     mystery:
     - ancestors
     range: 30 feet
@@ -1648,7 +1648,7 @@ pf2e_spells:
     - somatic
     duration: 1 round
     effect: You mime creating an invisible 10-foot-by-10-foot stretch of wall adjacent to you and within your reach. The wall is solid to those creatures that don't disbelieve it, even incorporeal creatures. You and your allies can voluntarily believe the wall exists to continue to treat it as solid, for instance to climb onto it. A creature that disbelieves the illusion is temporarily immune to your house of imaginary walls for 1 minute. The wall doesn't block creatures that didn't see your visual performance, nor does it block objects. The wall has AC 10, Hardness equal to double the spell's level, and HP equal to quadruple the spell's level.
-    base_level: 5
+    base_level: cantrip
     range: touch
     school: Illusion
     traits:
@@ -2116,7 +2116,7 @@ pf2e_spells:
     - verbal
     duration: 1 round
     effect: Your encouragement inspires your ally to succeed at a task. This counts as having taken sufficient preparatory actions to Aid your ally on a skill check of your choice, regardless of the circumstances. When you later use the Aid reaction, you can roll Performance instead of the normal skill check, and if you roll a failure, you get a success instead. If you are legendary in Performance, you automatically critically succeed. A GM might rule that you can't use this ability if the act of encouraging your ally would interfere with the skill check (such as a check to Sneak quietly or maintain a disguise).
-    base_level: 1
+    base_level: cantrip
     range: 60 feet
     school: Enchantment
     target: 1 ally
@@ -2135,7 +2135,7 @@ pf2e_spells:
     - verbal
     duration: 1 round
     effect: You inspire your allies with words or tunes of encouragement. You and all allies in the area gain a +1 status bonus to attack rolls, damage rolls, and saves against fear effects.
-    base_level: 1
+    base_level: cantrip
     school: Enchantment
     traits:
     - bard
@@ -2152,7 +2152,7 @@ pf2e_spells:
     - verbal
     duration: 1 round
     effect: You inspire your allies to protect themselves more effectively. You and all allies in the area gain a +1 status bonus to AC and saving throws, as well as resistance equal to half the spell's level to physical damage.
-    base_level: 2
+    base_level: cantrip
     school: Enchantment
     traits:
     - bard

--- a/game/config/pf2e_spells_k-o.yml
+++ b/game/config/pf2e_spells_k-o.yml
@@ -89,7 +89,7 @@ pf2e_spells:
     effect: "In your mind's eye, you see a path northward. You immediately know which direction is north (if it exists at your current location)."
     heighten:
     - 7: You can instead know the direction to a familiar location, such as a previous home or a favorite tavern.
-    base_level: 1
+    base_level: cantrip
     school: Divination
     tradition:
     - divine
@@ -643,7 +643,7 @@ pf2e_spells:
       3: You can target an unattended object with a Bulk of 1 or less.
       5: The range increases to 60 feet, and you can target an unattended object with a Bulk of 1 or less.
       7: The range increases to 60 feet, and you can target an unattended object with a Bulk of 2 or less.
-    base_level: 1
+    base_level: cantrip
     range: 30 feet
     school: Evocation
     target: 1 unattended object of light Bulk or less
@@ -950,7 +950,7 @@ pf2e_spells:
     effect: You mouth words quietly, but instead of coming out of your mouth, they're transferred directly to the ears of the target. While others can't hear your words any better than if you normally mouthed them, the target can hear your words as if they were standing next to you. The target can give a brief response as a reaction, or as a free action on their next turn if they wish, but they must be able to see you and be within range to do so. If they respond, their response is delivered directly to your ear, just like the original message.
     heighten:
       3: The spell's range increases to 500 feet.
-    base_level: 1
+    base_level: cantrip
     range: 120 feet
     school: Illusion
     target: 1 creature
@@ -1444,7 +1444,7 @@ pf2e_spells:
     - verbal
     duration: 1 minute
     effect: You read slightly into the future and give fate a tiny push to achieve the result you desire. Once during the duration, when the target fails an attack roll, skill check, or saving throw and a +1 status bonus would turn a critical failure into a failure, or failure into a success, you grant the target a +1 status bonus to the check retroactively, changing the outcome appropriately. The spell then ends, and the target is temporarily immune for 1 minute. If you cast _nudge fate_ while a previous casting of this hex is still in effect, the previous effect ends.
-    base_level: 1
+    base_level: cantrip
     range: 30 feet
     save: Will
     school: Divination

--- a/game/config/pf2e_spells_p-t.yml
+++ b/game/config/pf2e_spells_p-t.yml
@@ -515,7 +515,7 @@ pf2e_spells:
     heighten:
       8: Add *adamantine* and *mithral* to the list of metals you can transform the item into.
   Prestidigitation:
-    base_level: 1
+    base_level: cantrip
     school: Evocation
     traits:
     - cantrip
@@ -663,9 +663,8 @@ pf2e_spells:
       8: Increase the damage tp 8d4 and the persistent damage on a critical hit to 8d4.
       9: Increase the damage to 9d4 and the persistent damage on a critical hit to 9d4.
       10: Increase the damage to 10d4 and the persistent damage on a critical hit to 10d4.
-    base_level: 1
+    base_level: cantrip
     mystery:
-    - Ash
     - flames
     range: 30 feet
     school: Evocation
@@ -1032,7 +1031,7 @@ pf2e_spells:
     - 8d4
     - 9d4
     - 10d4
-    base_level: 1
+    base_level: cantrip
     range: 120 feet
     school: Evocation
     target: 1 creature
@@ -1056,7 +1055,7 @@ pf2e_spells:
     heighten:
       3: You can target up to 10 objects.
       6: You can target any number of objects.
-    base_level: 1
+    base_level: cantrip
     mystery:
     - lore
     range: 30 feet
@@ -2139,7 +2138,7 @@ pf2e_spells:
       5: The shield has Hardness 15.
       7: The shield has Hardness 20.
       9: The shield has Hardness 25.
-    base_level: 1
+    base_level: cantrip
     mystery:
     - battle
     school: Abjuration
@@ -2264,7 +2263,7 @@ pf2e_spells:
     - somatic
     duration: 1 minute
     effect: Drawing your hand in a sweeping gesture, you shroud the target in a veil of night. The target's eyes are blanketed in darkness. If you cast this hex on a willing ally (for instance, one with light blindness), the ally can choose which result it gets without rolling. Regardless of the outcome, the target is then temporarily immune for 1 minute.%r**Success** The target is unaffected.%r**Failure** The target is shrouded in murky darkness. Unless the target has darkvision, other creatures are concealed to it.
-    base_level: 1
+    base_level: cantrip
     range: 30 feet
     save: Will
     school: Evocation
@@ -2286,7 +2285,7 @@ pf2e_spells:
       3: The sigil instead fades after 1 month.
       5: The sigil instead fades after 1 year.
       7: The sigil never fades.
-    base_level: 1
+    base_level: cantrip
     range: touch
     school: Transmutation
     target: 1 creature or object
@@ -2412,7 +2411,7 @@ pf2e_spells:
     heighten:
       6: You can Sustain the Spell for up to 2 hours.
       9: You can Sustain the Spell for up to 4 hours.
-    base_level: 3
+    base_level: cantrip
     school: Enchantment
     traits:
     - bard
@@ -2428,7 +2427,7 @@ pf2e_spells:
     - verbal
     duration: 1 round
     effect: You bolster your allies' physical strength with a hearty exhortation. You and your allies gain a +1 status bonus to Athletics checks and to their DCs against Athletics skill actions such as Disarm, Shove, and Trip.%r %r**Special** If you have the *inspire heroics* composition spell, you can use that composition to improve the bonus granted by *song of strength* in the same way as *inspire courage* or *inspire defense*.
-    base_level: 1
+    base_level: cantrip
     school: Enchantment
     traits:
     - bard
@@ -2988,7 +2987,7 @@ pf2e_spells:
     - somatic
     - verbal
     effect: Positive energy shuts death's door. The target loses the dying condition, though it remains unconscious at 0 Hit Points.
-    base_level: 1
+    base_level: cantrip
     mystery:
     - life
     range: 30 feet
@@ -3075,11 +3074,11 @@ pf2e_spells:
     duration: 1 minute
     effect: Intense fervor fills the target creature, empowering their blows. The target gains a +2 status bonus to damage rolls. Once this spell ends, the target becomes temporarily immune for 1 minute.
     heighten:
-    - +3
-    - +4
-    - +5
-    - +6
-    base_level: 1
+      2: The status bonus to damage increases by 1.
+      4: The status bonus to damage increases by 2.
+      6: The status bonus to damage increases by 3.
+      8: The status bonus to damage increases by 4.
+    base_level: cantrip
     range: 30 feet
     school: Enchantment
     target: 1 creature
@@ -3518,7 +3517,7 @@ pf2e_spells:
     effect: You materialize a handheld musical instrument in your grasp. The instrument is typical for its type, but it plays only for you. The instrument vanishes when the spell ends. If you cast *summon instrument* again, any instrument you previously summoned disappears.
     heighten:
       5: The instrument is instead a virtuoso handheld instrument.
-    base_level: 1
+    base_level: cantrip
     school: Conjuration
     tradition:
     - divine
@@ -3722,7 +3721,7 @@ pf2e_spells:
     heighten:
       2: The effects last for 2 rounds.
       4: The effects last for 1 minute.
-    base_level: 1
+    base_level: cantrip
     range: 30 feet
     school: Conjuration
     target: 1 creature
@@ -3802,7 +3801,7 @@ pf2e_spells:
     - 8d6
     - 9d6
     - 10d6
-    base_level: 1
+    base_level: cantrip
     range: 30 feet
     school: Evocation
     target: 1 creature
@@ -4314,7 +4313,7 @@ pf2e_spells:
     - somatic
     duration: 1 round
     effect: You dance at a lively tempo, speeding your allies' movement. You and all allies in the area gain a +10-foot status bonus to all Speeds for 1 round.
-    base_level: 2
+    base_level: cantrip
     school: Enchantment
     traits:
     - bard

--- a/game/config/pf2e_spells_u-z.yml
+++ b/game/config/pf2e_spells_u-z.yml
@@ -1009,7 +1009,7 @@ pf2e_spells:
     - verbal
     duration: 1 minute
     effect: With a few words, you convince a wild creature you are a kindred spirit, making it reluctant to harm you. The target must attempt a Will save. Regardless of the outcome, the target is then temporarily immune for 1 minute.%r**Critical Success** The target is unaffected.%r**Success** When the target attempts an attack roll or skill check that would harm you, it takes a –2 status penalty to its roll.%r**Failure** As success, but the target also becomes sickened 1 each time it damages you.%r**Critical Failure** As success, but the target also becomes sickened 2 each time it damages you.
-    base_level: 1
+    base_level: cantrip
     range: 30 feet
     save: Will
     school: Enchantment

--- a/plugins/pf2emagic/help/en/pf2e_chargen_magic.md
+++ b/plugins/pf2emagic/help/en/pf2e_chargen_magic.md
@@ -14,6 +14,8 @@ For most classes and ancestries, there isn't a lot to do for magic in character 
 
 All spells selected must be common spells to be selected in character generation or advancement. Uncommon and rare spells require a request to the game admins.
 
-Clerics get a divine font. This is populated automagically for some deities, but clerics of select deities must choose. cg_review will tell you if you need to choose. To do so: 
+Clerics get a divine font. This is populated automagically for some deities, but clerics of select deities must choose. `cg/review` will tell you if you need to choose. To do so: 
 
-`dfont <heal or harm>`: Chooses your divine font. 
+`dfont <heal or harm>`: Chooses your divine font.
+
+**Once you are done selecting spells, you will have to input `rest` to see your spells on the magic section of your sheet.** You cannot `rest` until your character is approved.


### PR DESCRIPTION
I adjusted the magic helpfile to contain a line about resting.

I also ran through the spell YMLs and converted everything that's a cantrip to, well, be a cantrip.

**NOTE**:
Allegro, Dirge of Doom, House of Imaginary Walls, Inspire Defense, Song of Marching, and Triple Time are all bard cantrips that start at a level higher than 'cantrip 1'. These are special composition cantrips. However, they *should* be special focus spell cantrips that can't be selected unless they have the feat, so I think it's fine to define them as `base_level: cantrip`.