### PR TITLE
Ancestry/heritage edits, ancestry feats, and more.

### DIFF
--- a/game/config/pf2e_ancestry.yml
+++ b/game/config/pf2e_ancestry.yml
@@ -21,8 +21,10 @@ pf2e_ancestry:
     - Changeling
     - Dar
     - Elfbane
+    - Ghaluch
     - Niasa
     - Runtboss
+    - Silyara
     - Smokeworker
     - Warmarch
     - Warrenbred
@@ -64,11 +66,13 @@ pf2e_ancestry:
     - Ashen One
     - Changeling
     - Dar
+    - Ghaluch
     - Gutsy
     - Hillock
     - Jinxed-bassin
     - Niasa
     - Nomadic
+    - Silyara
     - Twilight
     - Wildwood
     feats:
@@ -225,9 +229,11 @@ pf2e_ancestry:
     - Changeling
     - Charhide
     - Dar
+    - Ghaluch
     - Irongut
     - Niasa
     - Razortooth
+    - Silyara
     - Snow
     - Unbreakable
     feats:
@@ -280,8 +286,10 @@ pf2e_ancestry:
     - Changeling
     - Dar
     - Fey-Touched
+    - Ghaluch
     - Niasa
     - Sensate
+    - Silyara
     - Umbral
     - Wellspring (Arcane)
     - Wellspring (Divine)
@@ -329,9 +337,9 @@ pf2e_ancestry:
     - Ashen One
     - Changeling
     - Dar
-    - Half-Sil
-    - Half-Oruch
+    - Ghaluch
     - Niasa
+    - Silyara
     - Skilled
     - Versatile
     feats:
@@ -426,8 +434,10 @@ pf2e_ancestry:
     - Dar
     - Death Warden
     - Forge
+    - Ghaluch
     - Niasa
     - Rock
+    - Silyara
     - Strong-Blooded
     feats:
       1:
@@ -438,7 +448,6 @@ pf2e_ancestry:
       - Rock Runner
       - Stonecunning
       - Unburdened Iron
-      - Vengeful Hatred
       5:
       - Boulder Roll
       - Defy the Darkness
@@ -480,6 +489,7 @@ pf2e_ancestry:
     - Deep Oruch
     - Hold-Scarred
     - Niasa
+    - Silyara
     - Rainfall
     feats:
       1:
@@ -529,6 +539,7 @@ pf2e_ancestry:
     - Cavern
     - Changeling
     - Dar
+    - Ghaluch
     - Niasa
     - Seer
     - Whisper

--- a/game/config/pf2e_ancestry.yml
+++ b/game/config/pf2e_ancestry.yml
@@ -353,11 +353,13 @@ pf2e_ancestry:
       - Unconventional Weaponry
       5:
       - Adaptive Adept
+      - Clever Improviser
       - Sense Allies
       9:
       - Cooperative Soul
       - Group Aid
       - Hardy Traveler
+      - Incredible Improvisation
       - Multitalented
       13:
       - Advanced General Training

--- a/game/config/pf2e_deities.yml
+++ b/game/config/pf2e_deities.yml
@@ -64,7 +64,7 @@ pf2e_deities:
     - Turn your back on a chance to challenge yourself.
     - Bully those weaker than yourself.
     - Fail to acknowledge when you've been bested.
-  Animus: SPOILER
+  Animus:
     allowed_alignments:
     - NG
     - LN

--- a/game/config/pf2e_deities.yml
+++ b/game/config/pf2e_deities.yml
@@ -19,7 +19,7 @@ pf2e_deities:
     - Family
     - Healing
     - Pain
-    - Duty
+    - Repose
     cleric_spells:
     - Soothe
     - Resilient Sphere
@@ -34,12 +34,12 @@ pf2e_deities:
     - Betray the trust of a community.
   Angoron:
     allowed_alignments:
+    - LG
     - CG
     - NG
-    - LG
+    - LN
     - N
     - CN
-    - LN
     magic_stats:
       divine_font:
       - harm
@@ -63,37 +63,37 @@ pf2e_deities:
     anathema:
     - Turn your back on a chance to challenge yourself.
     - Bully those weaker than yourself.
-    - Fail to acknowledge when you’ve been bested.
-#  Animus: SPOILER
-#    allowed_alignments:
-#    - NG
-#    - LN
-#    - N
-#    - CN
-#    magic_stats:
-#      divine_font:
-#      - heal
-#      - harm
-#    divine_ability: Wisdom
-#    divine_skill: Arcana
-#    fav_weapon: quarterstaff
-#    domains:
-#    - Magic
-#    - Glyph
-#    - Knowledge
-#    - Fate
-#    cleric_spells:
-#    - Magic Missile
-#    - Telepathy
-#    - Prismatic Spray
-#    edicts:
-#    - Teach and be taught.
-#    - Serve the interests of magic.
-#    - Preserve knowledge.
-#    anathema:
-#    - Take part in the destruction of knowledge.
-#    - Allow passion to rule judgement.
-#    - Use magic for pedestrian purposes.
+    - Fail to acknowledge when you've been bested.
+  Animus: SPOILER
+    allowed_alignments:
+    - NG
+    - LN
+    - N
+    - CN
+    magic_stats:
+      divine_font:
+      - heal
+      - harm
+    divine_ability: Wisdom
+    divine_skill: Arcana
+    fav_weapon: quarterstaff
+    domains:
+    - Magic
+    - Glyph
+    - Knowledge
+    - Fate
+    cleric_spells:
+    - Magic Missile
+    - Telepathy
+    - Prismatic Spray
+    edicts:
+    - Teach and be taught.
+    - Serve the interests of magic.
+    - Preserve knowledge.
+    anathema:
+    - Take part in the destruction of knowledge.
+    - Allow passion to rule judgement.
+    - Use magic for pedestrian purposes.
   Caracoroth:
     allowed_alignments:
     - CN
@@ -104,7 +104,7 @@ pf2e_deities:
     - Strength
     - Charisma
     divine_skill: Survival
-    fav_weapon: unarmed
+    fav_weapon: claw blade
     domains:
     - Ambition
     - Destruction
@@ -117,17 +117,17 @@ pf2e_deities:
     edicts:
     - Follow your instincts.
     - Delight in destruction.
-    - Reject the weak.
+    - Pursue strength.
     anathema:
-    - Be a coward.
     - Show weakness.
     - Talk when actions serve better.
+    - Refuse power when it is offered.
   Ceinara:
     allowed_alignments:
     - NG
     - CG
-    - CN
     - N
+    - CN
     magic_stats:
       divine_font:
       - heal
@@ -149,9 +149,9 @@ pf2e_deities:
     - Patronize the arts and inspiration in all its forms.
     - Delight in creation.
     anathema:
-    - Support or protect the status quo, resort to rudeness when politeness will serve.
-    - Discourage someone from their inspiration.
-    - Hide your emotions for any reason.
+    - Allow your passion to fade from fear.
+    - Destroy an artistic expression.
+    - Discourage an artist from pursuing their dreams.
   Daeus:
     allowed_alignments:
     - LG
@@ -168,19 +168,19 @@ pf2e_deities:
     domains:
     - Wyrmkin
     - Truth
-    - Zeal
+    - Duty
     - Sun
     cleric_spells:
     - True Strike
     - Fire Shield
     - Dragon Form
     edicts:
-    - Justice isn’t perfect; always try to make it better.
+    - Justice isn't perfect; always try to make it better.
     - Share the truths you learn.
-    - Protect those who cannot defend themselves.
+    - Protect the people who need it.
     anathema:
     - Abide injustice when you can step forward.
-    - Choose for another who can choose for themselves.
+    - Mistake vengeance for justice.
     - Cheat, deceive, or undermine those who have placed trust in you.
   Dana:
     allowed_alignments:
@@ -198,19 +198,19 @@ pf2e_deities:
     domains:
     - Earth
     - Nature
-    - Change
+    - Wood
     - Swarm
     cleric_spells:
     - Pummeling Rubble
     - Speak with Plants
     - Tangling Creepers
     edicts:
-    - Defend nature’s bounty against those who would pillage it.
-    - Honor the land as your mother; let none bring Her to harm.
+    - Defend nature's bounty against those who would pillage it.
     - Tend the gardens of the earth in all their forms.
+    - Embody the sprawling order of nature in your other pursuits.
     anathema:
     - Engage in wanton destruction.
-    - Tolerate the poisoning of the earth.
+    - Suffer the poisoning of the earth.
     - Hunt rampantly.
   Deimos:
     allowed_alignments:
@@ -224,10 +224,10 @@ pf2e_deities:
     divine_skill: Deception
     fav_weapon: light hammer
     domains:
-    - Decay
+    - Delirium
     - Secrecy
     - Trickery
-    - Vigil
+    - Confidence
     cleric_spells:
     - Illusory Disguise
     - Crushing Despair
@@ -259,15 +259,15 @@ pf2e_deities:
     - Moon
     - Magic
     - Dreams
-    - Change
+    - Fate
     cleric_spells:
     - Sleep
     - Scrying
     - Dream Council
     edicts:
-    - Take the long view and always consider the greater good of all.
-    - Must use magic responsibly, and challenge those who do not.
-    - Seek to rescue those lycanthropes you can from the grip of Caracoroth.
+    - Take the long view and always consider the greater good.
+    - Use magic responsibly, and challenge those who do not.
+    - Soothe the lycanthropes who are caught in the maw of Caracoroth.
     anathema:
     - Use spells or magic that deny the target their free will.
     - Sacrifice the future for short-term benefit.
@@ -288,7 +288,7 @@ pf2e_deities:
     - Earth
     - Nature
     - Travel
-    - Air
+    - Freedom
     cleric_spells:
     - Longstrider
     - Wall of Thorns
@@ -300,7 +300,7 @@ pf2e_deities:
     anathema:
     - Kill uncleanly and mercilessly.
     - Smother the wild rather than protect it.
-    - Hoard the resources of the wilderness.
+    - Hoard wild resources.
   Gunahkar:
     allowed_alignments:
     - N
@@ -315,14 +315,14 @@ pf2e_deities:
     - Destruction
     - Death
     - Indulgence
-    - Void
+    - Pain
     cleric_spells:
     - Grim Tendrils
     - Paralyze
     - Blister
     edicts:
-    - Do not stop suffering.
-    - Do not fear sickness.
+    - Suffer.
+    - Welcome sickness.
     - Endure all you can.
     anathema:
     - Stop the faithful from feeling their pain.
@@ -339,13 +339,13 @@ pf2e_deities:
     divine_skill: Society
     fav_weapon: kukri
     domains:
-    - Cold
     - Fate
     - Pain
-    - Undeath
+    - Soul
+    - Zeal
     cleric_spells:
     - Ill Omen
-    - Ice Storm
+    - Phantasmal Killer
     - True Target
     edicts:
     - Punish those that harm you.
@@ -358,8 +358,8 @@ pf2e_deities:
   Kor:
     allowed_alignments:
     - CG
-    - CN
     - N
+    - CN
     magic_stats:
       divine_font:
       - harm
@@ -376,9 +376,9 @@ pf2e_deities:
     - Haste
     - Weapon Storm
     edicts:
-    - Be brave enough to fight at My side.
-    - Be wise enough to achieve a glorious death.
-    - Be prepared to train to achieve glory.
+    - Be brave enough to fight at Kor's side.
+    - Achieve a glorious death.
+    - Train to achieve glory.
     anathema:
     - Be the first to leave the battlefield.
     - Mistake bravery for foolishness.
@@ -403,13 +403,13 @@ pf2e_deities:
     - Dominate
     - Force Cage
     edicts:
-    - Never cease your toil.
-    - A hard day's work is its own reward.
-    - You are entitled to what you earn.
+    - Labor unflinchingly at your work.
+    - Strive for perfection in all affairs.
+    - Be entitled to what you earn.
     anathema:
-    - Being lazy.
-    - Shirking duties.
-    - Taking more than you're owed.
+    - Be lazy.
+    - Shirk your duties and responsibilities.
+    - Take more than you're owed.
   Navos:
     allowed_alignments:
     - LG
@@ -426,18 +426,18 @@ pf2e_deities:
     - Time
     - Secrecy
     - Perfection
-    - Star
+    - Knowledge
     cleric_spells:
     - Deja Vu
     - Dimension Door
     - Blanket of Stars
     edicts:
     - Learn from the past; do not dwell on it.
-    - Be aware that you are making history now.
-    - Seek to encourage the balance of time.
+    - Act wisely and cautiously in the present day.
+    - Work for a better future.
     anathema:
     - Be consumed by something you cannot change.
-    - Fail to perceive your own actions.
+    - Fail to perceive the weight of your own actions.
     - Try to change past events.
   Rada:
     allowed_alignments:
@@ -452,18 +452,18 @@ pf2e_deities:
     divine_skill: Diplomacy
     fav_weapon: trident
     domains:
-    - Water
-    - Wealth
-    - Travel
     - Air
+    - Travel
+    - Water
+    - Weather
     cleric_spells:
-    - Hydraulic Push
+    - Water Breathing
     - Mariner's Curse
     - Horrid Wilting
     edicts:
     - Honor a fair trade.
     - The sea is owed a portion of your keep.
-    - Harvest only what you need.
+    - Take only what you need from the waters.
     anathema:
     - Break a fair bargain.
     - Be a false guide to another.
@@ -482,27 +482,27 @@ pf2e_deities:
     divine_skill: Crafting
     fav_weapon: warhammer
     domains:
-    - Earth
+    - Cities
     - Creation
-    - Perfection
+    - Ambition
     - Toil
     cleric_spells:
     - Telekinetic Projectile
     - Creation
     - Fiery Body
     edicts:
-    - Always tinker - a thing can always be better.
-    - Respect honest effort, even lacking in skill.
-    - Respect expertise.
+    - Always tinker and experiment for new possibilities.
+    - Respect honest effort, even if it lacks skill.
+    - Acknowledge expertise.
     anathema:
     - Engage in wanton destruction.
     - Strive for impossible perfection.
-    - Disrespect the act of creation.
+    - Disparage the act of creation.
   Serriel:
     allowed_alignments:
     - LG
-    - LN
     - NG
+    - LN
     - N
     magic_stats:
       divine_font:
@@ -522,8 +522,8 @@ pf2e_deities:
     - True Target
     edicts:
     - Enrich your community.
-    - Honor the ways of other communities.
-    - A thriving community is a growing one.
+    - Follow the laws and order of your community.
+    - Defend your community from threats.
     anathema:
     - Enrich yourself at the expense of your community.
     - Refuse to defend your community.
@@ -548,25 +548,25 @@ pf2e_deities:
     - Secret Page
     - Glibness
     edicts:
-    - Learn and tell your stories as often as possible.
+    - Tell your stories as often as possible.
     - Keep your secrets.
     - Unearth the secrets of others.
     anathema:
-    - Never shatter someone's illusions.
+    - Shatter someone's illusions.
     - Allow the truth to ruin a good story.
     - Give your secrets away for free.
   Tarien:
     allowed_alignments:
     - NG
     - CG
-    - CN
     - N
+    - CN
     magic_stats:
       divine_font:
       - heal
     divine_ability: Charisma
     divine_skill: Stealth
-    fav_weapon: Short Sword
+    fav_weapon: shortsword
     domains:
     - Luck
     - Travel
@@ -578,12 +578,12 @@ pf2e_deities:
     - Synesthesia
     edicts:
     - Find the small joys in everything.
-    - Understand that humility is the greatest teacher.
-    - It's only funny if others laugh too.
+    - Know that humility is the greatest teacher.
+    - Make others laugh, too.
     anathema:
-    - Make a joke of someone who doesn’t deserve it.
-    - Dogpile someone already being shamed.
-    - Ringing harm with your humor.
+    - Bring undue harm with your humor.
+    - Impair someone's freedom without good reason.
+    - Purposefully ruin everyone else's fun.
   Thul:
     allowed_alignments:
     - LN
@@ -596,16 +596,16 @@ pf2e_deities:
     divine_skill: Occultism
     fav_weapon: scythe
     domains:
-    - Undeath
-    - Indulgence
-    - Decay
     - Cold
+    - Decay
+    - Vigil
+    - Undeath
     cleric_spells:
     - Object Reading
     - Modify Memory
     - Polar Ray
     edicts:
-    - Do not fear death.
+    - Welcome death and undeath.
     - Gather as much experience as you can.
     - Serve the dead where you can.
     anathema:
@@ -640,5 +640,5 @@ pf2e_deities:
     - Try to ensure a peaceful passing.
     anathema:
     - Disturb the rest of the dead.
-    - Judge the worth of a person.
+    - Cast judgment on the worth of a person.
     - Command the fate of a soul.

--- a/game/config/pf2e_feat_ancestry.yml
+++ b/game/config/pf2e_feat_ancestry.yml
@@ -887,6 +887,11 @@ pf2e_feats:
     - Gnome
     traits:
     - uncommon
+    magic:
+      innate_spell:
+        7:
+        - Plane Shift
+        spell_trad: primal
     shortdesc: "The connection between you and the First World resonates within your body stronger than it does for most gnomes, allowing you to cross the threshold between the Material Plane and the First World. You gain plane shift as a primal innate spell. You can cast it twice per week. This can be used only to travel back and forth between the First World and the Material Plane. Due to your body's natural resonance, you can act as the spell focus, and you don't require a tuning fork."
     prereq:
       level: 17
@@ -1240,7 +1245,7 @@ pf2e_feats:
     assoc_ancestry: 
     - Human
     traits: []
-    shortdesc: "You've learned to split your focus between multiple classes with ease. You gain a 2nd-level multiclass dedication feat, even if you normally couldn't take another dedication feat until you take more feats from your current archetype.%r%rIf you're a half-sil, you don't need to meet the feat's ability score prerequisites."
+    shortdesc: "You've learned to split your focus between multiple classes with ease. You gain a 2nd-level multiclass dedication feat, even if you normally couldn't take another dedication feat until you take more feats from your current archetype.%r%rIf you're a silyara, you don't need to meet the feat's ability score prerequisites."
     prereq:
       level: 9
   Advanced General Training: # Ask Blue about this later
@@ -2266,7 +2271,7 @@ pf2e_feats:
     prereq:
       level: 1
       heritage: Aesa
-  Blessed Blood (Aesa): # Crafting mention
+  Blessed Blood (Aesa):
     feat_type: 
     - Ancestry
     assoc_ancestry: 
@@ -2361,7 +2366,8 @@ pf2e_feats:
     prereq:
       level: 9
       heritage: Aesa
-      lineage: Angelkin
+      feat:
+      - Angelkin
   Archon Magic:
     feat_type: 
     - Ancestry
@@ -2389,7 +2395,8 @@ pf2e_feats:
     prereq:
       level: 9
       heritage: Aesa
-      lineage: Lawbringer
+      feat: 
+      - Lawbringer
   Azata Magic:
     feat_type: 
     - Ancestry
@@ -2417,7 +2424,8 @@ pf2e_feats:
     prereq:
       level: 9
       heritage: Aesa
-      lineage: Musetouched
+      feat:
+      - Musetouched
   Celestial Wings: # Speed # Ask Blue about this later
     feat_type: 
     - Ancestry
@@ -2491,7 +2499,7 @@ pf2e_feats:
     prereq:
       level: 13
       heritage: Aesa
-  Aesa's Mercy: # Casting is funky # Ask Blue about this later
+  Celestial Strikes:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
@@ -2508,17 +2516,79 @@ pf2e_feats:
     - Sildanyar
     traits:
     - aesa
-    magic:
-      innate_spell:
-        4:
-        - Neutralize Poison
-        - Remove Curse
-        - Remove Disease
-        spell_trad: primal
-    shortdesc: "Your celestial powers allow you to remove lesser afflictions with ease. Each day, you can cast two 4th-level divine innate spells. You can choose from the following spells each time you cast: remove curse, remove disease, and neutralize poison."
+    shortdesc: Your connection to good arms all your attacks against forces of evil. All your weapon and unarmed Strikes deal 1 additional good damage and have the good and magical traits.
     prereq:
       level: 13
       heritage: Aesa
+  Summon Celestial Kin:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - aesa
+    shortdesc: Your connection to good arms all your attacks against forces of evil. All your weapon and unarmed Strikes deal 1 additional good damage and have the good and magical traits.
+    prereq:
+      level: 13
+      heritage: Aesa
+      orfeat:
+      - Angelkin
+      - Lawbringer
+      - Musetouched
+  Celestial Word:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - aesa
+    shortdesc: You can call forth a holy word from the celestial realms to punish your foes. Once per day, you can cast _divine decree_ as a 7th-level divine innate spell.
+    prereq:
+      level: 17
+      heritage: Aesa
+  Eternal Wings (Aesa):
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - aesa
+    shortdesc: Your wings are now a permanent part of your body. You gain the effects of Celestial Wings at all times, rather than just once per day for 10 minutes.
+    prereq:
+      level: 17
+      heritage: Aesa
+      feat:
+      - Celestial Wings
 # Ashen One Ancestry Feats
   Ashen Lore:
     feat_type: 
@@ -2665,6 +2735,12 @@ pf2e_feats:
     - Sildanyar
     traits:
     - ashen one
+    magic:
+      innate_spell:
+        2:
+        - augury
+        - gentle repose
+        spell_trad: divine
     shortdesc: Your connection to psychopomps gives you the power to glimpse the near future and protect corpses from the ravages of undeath. You can cast augury and gentle repose each once per day as 2nd-level divine innate spells.
     prereq:
       level: 9
@@ -2690,7 +2766,7 @@ pf2e_feats:
     prereq:
       level: 9
       heritage: Ashen One
-  Resist Ruin: # Resistance # Innate Spellcasting
+  Resist Ruin: # Resistance
     feat_type:
     - Ancestry
     assoc_ancestry: 
@@ -2707,6 +2783,11 @@ pf2e_feats:
     - Sildanyar
     traits:
     - ashen one
+    magic:
+      innate_spell:
+        5:
+        - Death Ward
+        spell_trad: divine
     shortdesc: Your ashen one heritage allows you to extend protection against negative energy to yourself or an ally in need. You gain resistance 5 to negative energy, and once per day, you can cast death ward as a divine innate spell.
     prereq:
       level: 13
@@ -2729,6 +2810,11 @@ pf2e_feats:
     traits:
     - ashen one
     - Uncommon
+    magic:
+      innate_spell:
+        7:
+        - Plane Shift
+        spell_trad: divine
     shortdesc: You have a powerful connection to the Gray Halls, granting you the ability to travel to and from the Gray Halls. You gain plane shift as a divine innate spell. You can cast it twice per week. This can be used only to travel to the Gray Halls or from the Gray Halls to the Material Plane. Due to your unique connection to the Gray Halls, your body serves as the focus, and you don't require a tuning fork.
     prereq:
       level: 17
@@ -3143,6 +3229,11 @@ pf2e_feats:
     - Sildanyar
     traits:
     - dar
+    magic:
+      innate_spell:
+        1:
+        - Charm
+        spell_trad: divine
     shortdesc: The powers of domination employed by your progenitors have manifested in you as well. Once per day, you can cast _charm_ as a 1st-level divine innate spell.
     prereq:
       level: 5
@@ -3227,6 +3318,12 @@ pf2e_feats:
     - Sildanyar
     traits:
     - dar
+    magic:
+      innate_spell:
+        2:
+        - Animal Form
+        - Obscuring Mist
+        spell_trad: divine
     shortdesc: You can tap into the magic that runs through your blood. You gain animal form (wolf only, using the statistics for a canine) and obscuring mist as 2nd-level divine innate spells. You can cast each of these spells once per day.
     prereq:
       level: 9
@@ -3273,89 +3370,153 @@ pf2e_feats:
     - Sildanyar
     traits:
     - dar
-    shortdesc: You call forth the blood of your foes to grant you vigor. Once per day, you can cast vampiric exsanguination as a 7th-level divine innate spell.
+    magic:
+      innate_spell:
+        7:
+        - Vampiric Exsanguination
+        spell_trad: divine
+    shortdesc: You call forth the blood of your foes to grant you vigor. Once per day, you can cast _vampiric exsanguination_ as a 7th-level divine innate spell.
     prereq:
       level: 17
       heritage: Dar
-# Half-Sil Ancestry Feats
+# Silyara Ancestry Feats
   Earned Glory:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Goblin
+    - Gnome
     - Human
+    - Khazad
+    - Oruch
+    - Sildanyar
     traits:
-    - half-sil
-    shortdesc: Sildanyari are often skeptical of their half-sil kin, and you are experienced at telling stories of your accomplishments to gain their respect. You are trained in Performance. If you would automatically become trained in Performance (from your background or class, for example), you instead become trained in a skill of your choice.
+    - silyara
+    shortdesc: Sildanyari are often skeptical of their silyara kin, and you are experienced at telling stories of your accomplishments to gain their respect. You are trained in Performance. If you would automatically become trained in Performance (from your background or class, for example), you instead become trained in a skill of your choice.
     prereq:
       level: 1
-      heritage: Half-Sil
+      heritage: Silyara
   Sil Atavism:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Goblin
+    - Gnome
     - Human
+    - Khazad
+    - Oruch
+    - Sildanyar
     traits:
-    - half-sil
-    shortdesc: Your sildanyari blood runs particularly strong, granting you features far more sildanyari than those of a typical half-sil. You may also have been raised among sil, steeped in your sildanyari ancestors' heritage. You gain the benefits of the sil heritage of your sildanyari parent or ancestors. You typically can't select a heritage that depends on or improves an sildanyari feature you don't have. For example, you couldn't gain the cavern sil's darkvision ability if you didn't have low-light vision. In these cases, at the GM's discretion, you might gain a different benefit.%r%r**Special**You can take this feat only at 1st level, and you can't retrain out of this feat or into this feat.
+    - silyara
+    shortdesc: Your sildanyari blood runs particularly strong, granting you features far more sildanyari than those of a typical silyara. You may also have been raised among sil, steeped in your sildanyari ancestors' heritage. You gain the benefits of the sil heritage of your sildanyari parent or ancestors. You typically can't select a heritage that depends on or improves an sildanyari feature you don't have. For example, you couldn't gain the cavern sil's darkvision ability if you didn't have low-light vision. In these cases, at the GM's discretion, you might gain a different benefit.%r%r**Special**You can take this feat only at 1st level, and you can't retrain out of this feat or into this feat.
     prereq:
       level: 1
-      heritage: Half-Sil
+      heritage: Silyara
   Inspire Imitation:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Goblin
+    - Gnome
     - Human
+    - Khazad
+    - Oruch
+    - Sildanyar
     traits:
-    - half-sil
+    - silyara
     shortdesc: Your actions inspire your allies to great achievements. Whenever you critically succeed at a skill check, you automatically qualify to use the Aid reaction when attempting to help an ally using the same skill, even without spending an action to prepare to do so.
     prereq:
       level: 5
-      heritage: Half-Sil
-  Supernatural Charm: # Spellcasting
+      heritage: Silyara
+  Supernatural Charm:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Goblin
+    - Gnome
     - Human
-    shortdesc: The sildanyari magic in your blood manifests as a force you can use to become more appealing or alluring. You can cast 1st-rank charm as an arcane innate spell once per day.
+    - Khazad
+    - Oruch
+    - Sildanyar
+    magic:
+      innate_spell:
+        1:
+        - Charm
+        spell_trad: arcane
+    shortdesc: The sildanyari magic in your blood manifests as a force you can use to become more appealing or alluring. You can cast 1st-rank _charm_ as an arcane innate spell once per day.
     prereq:
       level: 5
-      heritage: Half-Sil
+      heritage: Silyara
     init_magic: true
-  Supernatural Charm: # Spellcasting
+  Pinch Time:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Goblin
+    - Gnome
     - Human
-    shortdesc: One of your parents has a human life span and another an elven life span, with your own somewhere between. As a result, you have an unusual perspective on time, which you've learned to manifest to aid yourself in moments of stress. You gain haste as a 3rd-level arcane innate spell, though you can target only yourself. You can Cast this Spell once per day.
+    - Khazad
+    - Oruch
+    - Sildanyar
+    magic:
+      innate_spell:
+        1:
+        - haste
+        spell_trad: arcane
+    shortdesc: One of your parents has a life span consistent with their ancestry and your other parent has a sil life span, with your own somewhere between. As a result, you have an unusual perspective on time, which you've learned to manifest to aid yourself in moments of stress. You gain haste as a 3rd-level arcane innate spell, though you can target only yourself. You can Cast this Spell once per day.
     prereq:
       level: 9
-      heritage: Half-Sil
+      heritage: Silyara
     init_magic: true
-# Half-Oruch Ancestry Feats
+# Ghaluch Ancestry Feats
   Monstrous Peacemaker:
     feat_type: 
     - Ancestry
-    assoc_ancestry: 
+    assoc_ancestry:
+    - Arvek
+    - Bassin
+    - Goblin
+    - Gnome
     - Human
+    - Khazad
+    - Oruch
+    - Sildanyar
     traits:
-      - half-oruch
-    shortdesc: Your dual human and oruch nature has given you a unique perspective, allowing you to bridge the gap between humans and the many intelligent creatures in the world that humans consider monsters. You gain a +1 circumstance bonus to Diplomacy checks against non-humanoid intelligent creatures and against humanoids that are marginalized in human society (at the GM's discretion, but typically at least including giants, goblins, kobolds, and oruchs). You also gain this bonus on Perception checks to Sense the Motives of such creatures.
+    - ghaluch
+    shortdesc: Your dual nature has given you a unique perspective, allowing you to bridge the gap between humans and the many intelligent creatures in the world that humans consider monsters. You gain a +1 circumstance bonus to Diplomacy checks against non-humanoid intelligent creatures and against humanoids that are marginalized in mortal society (at the GM's discretion). You also gain this bonus on Perception checks to Sense the Motives of such creatures.
     prereq:
       level: 1
-      heritage: Half-Oruch
+      heritage: Ghaluch
   Oruch Sight:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Goblin
+    - Gnome
     - Human
+    - Khazad
+    - Oruch
+    - Sildanyar
     traits:
-    - half-oruch
+    - ghaluch
     shortdesc: Your oruch blood grants you the keen vision of your forebears. You gain darkvision, allowing you to see in darkness and dim light just as well as you can in bright light. However, in darkness, you see in black and white only.%r%r**Special**You can take this feat only at 1st level, and you can't retrain out of this feat or into this feat.
     prereq:
       level: 1
-      heritage: Half-Oruch
+      heritage: Ghaluch
 # Niasa Ancestry Feats
-  Fiendish Eyes: # Golarion Reference
+  Fiendish Eyes:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
@@ -3372,7 +3533,7 @@ pf2e_feats:
     - Sildanyar
     traits:
     - niasa
-    shortdesc: You were raised by a tiefling or a fiendish relative, or you've devoted yourself to researching the secrets of the fiendish realms. You gain the trained proficiency rank in Intimidation and Religion. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in a Lore skill related to the fiendish plane from which you trace your lineage (usually Abaddon Lore, Abyss Lore, or Hell Lore).
+    shortdesc: You can see in the darkness as easily as a fiend. You gain darkvision. **Special** You can select this feat only at 1st level, and you can't retrain into or out of this feat.
     prereq:
       level: 1
       heritage: Niasa
@@ -3393,6 +3554,10 @@ pf2e_feats:
     - Sildanyar
     traits:
     - niasa
+    grants:
+      skill:
+      - Intimidation
+      - Religion
     shortdesc: You were raised by a tiefling or a fiendish relative, or you've devoted yourself to researching the secrets of the fiendish realms. You gain the trained proficiency rank in Intimidation and Religion. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in a Lore skill related to the fiendish plane from which you trace your lineage (usually Abaddon Lore, Abyss Lore, or Hell Lore).
     prereq:
       level: 1
@@ -3437,6 +3602,9 @@ pf2e_feats:
     traits:
     - lineage
     - niasa
+    grants:
+      feat:
+      - Diehard
     shortdesc: Your lineage traces back to a demon, one of the manifestations of horrific forms of death that devour souls within their foul home of the Abyss. As a result, you cling tenaciously to the last shreds of your own life force. You gain the Diehard feat.
     prereq:
       level: 1
@@ -3460,6 +3628,12 @@ pf2e_feats:
     traits:
     - lineage
     - niasa
+    grants:
+      skill: 
+      - Deception
+      - Legal Lore
+      feat:
+      - Lie to Me
     shortdesc: Your lineage descends from devils, the conniving schemers of a malevolent hierarchy. You're as skilled at noticing lies and twisted wordings as you are at constructing them. You are trained in Deception and Legal Lore. If you were already trained in Deception (from your background or class, for example), you instead become trained in a skill of your choice. You also gain the Lie to Me skill feat.
     prereq:
       level: 1
@@ -3504,11 +3678,17 @@ pf2e_feats:
     traits:
     - lineage
     - niasa
+    grants:
+      skill:
+      - Athletics
+      assign:
+        feat:
+        - skill feat
     shortdesc: Your blood bears the mark of a demon, a living embodiment of sin from the fetid depths of the Abyss. Demonic power pulses through your veins and manifests in a different way for each pitborn, whether you have webbed fingers and thrive in the water, large hands capable of wrestling larger foes, or some other manifestation. You are trained in Athletics. If you were already trained in Athletics (from your background or class, for example), you instead become trained in a skill of your choice. You also gain any one common 1st-level skill feat with a prerequisite of trained in Athletics, as reflects the manifestation of your Abyssal blood.
     prereq:
       level: 1
       heritage: Niasa
-  Fiendish Resistance:
+  Fiendish Resistance: # Resistance
     feat_type: 
     - Ancestry
     assoc_ancestry: 
@@ -3546,7 +3726,221 @@ pf2e_feats:
     - Sildanyar
     traits:
     - niasa
+    magic:
+      innate_spell:
+        1:
+        - Bane
+        spell_trad: divine
     shortdesc: Whether your heart is pure or corrupt, you can call forth a malediction upon your foes. You can cast bane once per day as a 1st-level divine innate spell.
     prereq:
       level: 5
       heritage: Niasa
+  Daemon Magic:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - niasa
+    prereq:
+      level: 9
+      lineage: grimspawn
+    magic:
+      innate_spell:
+        2:
+        - death knell
+        - false life
+        spell_trad: divine
+    shortdesc: The magic of Abaddon runs through your blood, and you can wield that power. You can cast _death knell_ and _false life_ each once per day as 2nd-level divine innate spells.
+  Demon Magic:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - niasa
+    prereq:
+      level: 9
+      lineage: pitborn
+    magic:
+      innate_spell:
+        2:
+        - Paranoia
+        - Shatter
+        spell_trad: divine
+    shortdesc: You can channel the power of the Abyss through your heritage, producing terrible tangible effects. You can cast _paranoia_ and _shatter_ each once per day as 2nd-level divine innate spells.
+  Devil Magic:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - niasa
+    prereq:
+      level: 9
+      lineage: hellspawn
+    magic:
+      innate_spell:
+        2:
+        - Invisibility
+        - Misdirection
+        spell_trad: divine
+    shortdesc: Drawing on the infernal power of your sinister forbears, you mislead your foes with magical deception. You can cast _invisibility_ and _misdirection_ each once per day as 2nd-level divine innate spells.
+  Fiendish Wings:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - divine
+    - niasa
+    - morph
+    - transmutation
+    prereq:
+      level: 9
+    shortdesc: You can strain to call forth bat-like or otherwise fiendish wings from your back, similar in appearance to those of your fiendish ancestors. Once manifested, these wings remain for 10 minutes. You gain a fly Speed equal to your land Speed while you've manifested your wings.
+  Light from Darkness:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - niasa
+    prereq:
+      level: 9
+    shortdesc: You've battled the fiendish power within your nature and come out on top; whatever you decide to do with your life, for good or evil, will be your choice and your choice alone. This struggle has granted you powerful resistance against the divine. You gain a +1 circumstance bonus to all saving throws against divine effects.
+  Fiend's Door:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - niasa
+    prereq:
+      level: 13
+    magic:
+      innate_spell:
+        5:
+        - Dimension Door
+        spell_trad: divine
+    shortdesc: Like many fiends, you have the supernatural ability to teleport yourself to safety. Once per day, you can cast _dimension door_ as a 5th-level divine innate spell.
+  Summon Fiendish Kin:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - niasa
+    prereq:
+      level: 13
+      orfeat:
+        - Grimspawn
+        - Pitborn
+        - Hellspawn
+    magic:
+      innate_spell:
+        5:
+        - Summon Fiend
+        spell_trad: divine
+    shortdesc: You have a deep connection to the fiendish realms, allowing you to summon a fiend matching your own lineage. Once per day, you can cast _summon fiend_ as a 5th-level divine innate spell. The fiend you summon must match your own lineage.
+  Fiendish Word:
+    feat_type: 
+    - Ancestry
+    assoc_ancestry: 
+    - Arvek
+    - Bassin
+    - Ciith 
+    - Egalrin
+    - Goblin
+    - Gnome
+    - Human
+    - Kailli
+    - Khazad
+    - Oruch
+    - Sildanyar
+    traits:
+    - niasa
+    prereq:
+      level: 17
+    magic:
+      innate_spell:
+        7:
+        - Divine Decree
+        spell_trad: divine
+    shortdesc: You can call forth a blasphemous word from the fiendish realms to punish your foes. Once per day, you can cast divine decree as a 7th-level divine innate spell.
+  Relentless Wings:
+    prereq:
+      level: 17
+      feat:
+      - Fiendish Wings
+    shortdesc: Your wings are now a permanent part of your physiology. You gain the effects of Fiendish Wings at all times, rather than just once per day for 10 minutes.

--- a/game/config/pf2e_feat_ancestry.yml
+++ b/game/config/pf2e_feat_ancestry.yml
@@ -1201,6 +1201,18 @@ pf2e_feats:
       level: 5
       feat: 
       - Adaptive Adept
+  Clever Improviser:
+    feat_type:
+    - Ancestry
+    assoc_ancestry:
+    - Human
+    traits: []
+    grants:
+      feat:
+      - Untrained Improvisation
+    shortdesc: You've learned how to handle situations when you're out of your depth. You gain the Untrained Improvisation general feat. In addition, you can attempt skill actions that normally require you to be trained, even if you are untrained.
+    prereq:
+      level: 5
   Sense Allies:
     feat_type: 
     - Ancestry
@@ -1239,6 +1251,17 @@ pf2e_feats:
     shortdesc: "There's no journey too far or burden too heavy when your friends are at your side. Increase your maximum and encumbered Bulk limits by 1. In addition, you gain a +10-foot circumstance bonus to your Speed during overland travel."
     prereq:
       level: 9
+  Incredible Improvisation:
+    feat_type:
+    - Ancestry
+    assoc_ancestry:
+    - Human
+    traits: []
+    shortdesc: "A stroke of brilliance gives you a major advantage with a skill despite your inexperience. Gain a +4 circumstance bonus to the triggering skill check."
+    prereq:
+      level: 9
+      feat:
+      - Clever Improviser
   Multitalented: # Ask Blue about this later
     feat_type: 
     - Ancestry
@@ -1285,7 +1308,7 @@ pf2e_feats:
     prereq:
       level: 13
       feat:
-      - Unconventional Expertise
+      - Unconventional Weaponry
   Heroic Presence:
     feat_type: 
     - Ancestry
@@ -1569,7 +1592,7 @@ pf2e_feats:
     assoc_ancestry: 
     - Khazad
     traits: []
-    shortdesc: "You've learned cunning techniques to get the best effects out of your dwarven weapons. Whenever you critically hit using a battle axe, pick, warhammer, or a khazad weapon, you apply the weapon's critical specialization effect."
+    shortdesc: "You've learned cunning techniques to get the best effects out of your khazadi weapons. Whenever you critically hit using a battle axe, pick, warhammer, or a khazad weapon, you apply the weapon's critical specialization effect."
     prereq:
       level: 5
       feat: 
@@ -1931,7 +1954,7 @@ pf2e_feats:
     assoc_ancestry: 
     - Sildanyar
     traits: []
-    shortdesc: "You've spent countless hours studying the history of elves on your world and beyond and are a studied expert in your people's ways. If you critically fail a check to Recall Knowledge about elves, sildanyari society, or sildanyari history, you get a failure instead."
+    shortdesc: "You've spent countless hours studying the history of sildanyari on your world and beyond and are a studied expert in your people's ways. If you critically fail a check to Recall Knowledge about sildanyari, sildanyari society, or sildanyari history, you get a failure instead."
     prereq:
       level: 1
   Nimble Sil: # Ask Blue about this later # Speed
@@ -2036,7 +2059,7 @@ pf2e_feats:
     assoc_ancestry: 
     - Sildanyar
     traits: []
-    shortdesc: You are attuned to the weapons of your sildanyari ancestors and are particularly deadly when using them. Whenever you critically hit using an elf weapon or one of the weapons listed in Sildanyari Weapon Familiarity, you apply the weapon's critical specialization effect.
+    shortdesc: You are attuned to the weapons of your sildanyari ancestors and are particularly deadly when using them. Whenever you critically hit using a sil weapon or one of the weapons listed in Sildanyari Weapon Familiarity, you apply the weapon's critical specialization effect.
     prereq:
       level: 5
       feat: 
@@ -2058,7 +2081,7 @@ pf2e_feats:
     assoc_ancestry: 
     - Sildanyar
     traits: []
-    shortdesc: The arcane magic you possess grows in power and complexity. Choose one common 2nd-level spell from the same tradition as an innate spell you previously gained from another elf ancestry feat (from the arcane list if you have Otherworldly Magic, for example). You can cast that spell as an innate spell once per day, using the same tradition as the list you chose the spell from.%r%rYour magic is adaptable. By spending 1 day of downtime, you can change the spell you chose to a different common 2nd-level spell from the same tradition.
+    shortdesc: The arcane magic you possess grows in power and complexity. Choose one common 2nd-level spell from the same tradition as an innate spell you previously gained from another sildanyar ancestry feat (from the arcane list if you have Otherworldly Magic, for example). You can cast that spell as an innate spell once per day, using the same tradition as the list you chose the spell from.%r%rYour magic is adaptable. By spending 1 day of downtime, you can change the spell you chose to a different common 2nd-level spell from the same tradition.
     prereq:
       level: 9
   Sildanyar Step:
@@ -2092,17 +2115,17 @@ pf2e_feats:
     shortdesc: Though you know that you will eventually outlive your companions, seeing them at death's door brings clarity to your attacks. Make a Strike. Roll twice on the attack roll and use the higher result.
     prereq:
       level: 13
-  Elven Weapon Expertise:
+  Sildanyari Weapon Expertise:
     feat_type: 
     - Ancestry
     assoc_ancestry: 
     - Sildanyar
     traits: []
-    shortdesc: Your elven affinity blends with your class training, granting you great skill with elven weapons. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in longbows, composite longbows, longswords, rapiers, shortbows, composite shortbows, and all elf weapons in which you are trained.
+    shortdesc: Your sildanyari affinity blends with your class training, granting you great skill with sildanyari weapons. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in longbows, composite longbows, longswords, rapiers, shortbows, composite shortbows, and all sildanyar weapons in which you are trained.
     prereq:
       level: 13
       feat:
-      - Elven Weapon Familiarity
+      - Sildanyari Weapon Familiarity
   Universal Longevity:
     feat_type: 
     - Ancestry

--- a/game/config/pf2e_feat_general.yml
+++ b/game/config/pf2e_feat_general.yml
@@ -146,7 +146,7 @@ pf2e_feats:
     feat_type: 
     - General
     traits: []
-    shortdesc: You snap your shield in place to ward off a blow. Your shield prevents you from taking an amount of damage up to the shield’s Hardness. You and the shield each take any remaining damage, possibly breaking or destroying the shield.
+    shortdesc: You snap your shield in place to ward off a blow. Your shield prevents you from taking an amount of damage up to the shield's Hardness. You and the shield each take any remaining damage, possibly breaking or destroying the shield.
     prereq:
       level: 1
   Toughness:
@@ -229,12 +229,19 @@ pf2e_feats:
     prereq:
       level: 3
       combat_stats: Perception/expert
+  Untrained Improvisation:
+    feat_type:
+    - General
+    traits: []
+    shortdesc: You've learned how to handle situations when you're out of your depth. Your proficiency bonus to untrained skill checks is equal to half your level instead of +0. If you're 7th level or higher, the bonus increases to your full level instead. This doesn't allow you to use the skill's trained actions.
+    prereq:
+      level: 3
 # Level 7 General Feats
   Expeditious Retreat:
     feat_type:
     - General
     traits: []
-    shortdesc: You have a system that lets you search at great speed, finding details and secrets twice as quickly as others can. When Searching, you take half as long as usual to Search a given area. This means that while exploring, you double the Speed you can move while ensuring you’ve Searched an area before walking into it (up to half your Speed). If you’re legendary in Perception, you instead Search areas four times as quickly.
+    shortdesc: You have a system that lets you search at great speed, finding details and secrets twice as quickly as others can. When Searching, you take half as long as usual to Search a given area. This means that while exploring, you double the Speed you can move while ensuring you've Searched an area before walking into it (up to half your Speed). If you're legendary in Perception, you instead Search areas four times as quickly.
     prereq:
       level: 7
       skill: Perception/master

--- a/game/config/pf2e_feat_skill.yml
+++ b/game/config/pf2e_feat_skill.yml
@@ -7,7 +7,7 @@ pf2e_feats:
     - General
     assoc_skill: Acrobatics
     traits: []
-    shortdesc: Use Acrobatics to Perform.
+    shortdesc: You're an incredible acrobat, evoking wonder and enrapturing audiences with your prowess. It's almost a performance! You can roll an Acrobatics check instead of a Performance check when using the Perform action.
     prereq:
       level: 1
       skill: Acrobatics/trained  
@@ -16,7 +16,7 @@ pf2e_feats:
     - Skill
     - General
     traits: []
-    shortdesc: Become trained in another Lore subcategory.
+    shortdesc: Your knowledge has expanded to encompass a new field. Choose an additional Lore skill subcategory. You become trained in it. At 3rd, 7th, and 15th levels, you gain an additional skill increase you can apply only to the chosen Lore subcategory.%r%r**Special** You can select this feat more than once. Each time you must select a new subcategory of Lore and you gain the additional skill increases to that subcategory for the listed levels.
     prereq:
       level: 1
   Alchemical Crafting:
@@ -25,7 +25,7 @@ pf2e_feats:
     - General
     assoc_skill: Crafting
     traits: []
-    shortdesc: Craft alchemical items.
+    shortdesc: You can use the Craft activity to create alchemical items. When you select this feat, you immediately add the formulas for four common 1st-level alchemical items to your formula book.
     prereq:
       level: 1
       skill: Crafting/trained
@@ -35,7 +35,7 @@ pf2e_feats:
     - General
     assoc_skill: Arcana
     traits: []
-    shortdesc: Cast detect magic at will as an arcane innate spell.
+    shortdesc: Your study of magic allows you to instinctively sense its presence. You can cast 1st-level detect magic at will as an arcane innate spell. If you're a master in Arcana, the spell is heightened to 3rd level; if you're legendary, it is heightened to 4th level.
     prereq:
       level: 1
       skill: Arcana/trained
@@ -45,7 +45,7 @@ pf2e_feats:
     - General
     assoc_skill: Athletics
     traits: []
-    shortdesc: Don armor more quickly.
+    shortdesc: After your service aiding armored combatants, you are practiced in helping yourself and others don heavy gear. You can attempt an Athletics or Warfare Lore check with a DC determined by the GM (but usually 15 for common armor, DC 20 for uncommon armor, and DC 25 for rare armor) to halve the time you take to don armor. You can halve an ally's time to don armor by working with them to don the armor and succeeding at an Athletics or Warfare Lore check against the same DC.
     prereq:
       level: 1
       orskill: 
@@ -58,7 +58,7 @@ pf2e_feats:
     assoc_skill: Acrobatics
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Acrobatics/trained
@@ -69,7 +69,7 @@ pf2e_feats:
     assoc_skill: Arcana
     traits:
     - fortune 
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Arcana/trained
@@ -80,7 +80,7 @@ pf2e_feats:
     assoc_skill: Athletics
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Athletics/trained
@@ -91,7 +91,7 @@ pf2e_feats:
     assoc_skill: Crafting
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Crafting/trained
@@ -102,7 +102,7 @@ pf2e_feats:
     assoc_skill: Deception
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Deception/trained
@@ -113,7 +113,7 @@ pf2e_feats:
     assoc_skill: Diplomacy
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Diplomacy/trained
@@ -124,7 +124,7 @@ pf2e_feats:
     assoc_skill: Intimidation
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Intimidation/trained
@@ -135,7 +135,7 @@ pf2e_feats:
     assoc_skill: Medicine
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Medicine/trained
@@ -146,7 +146,7 @@ pf2e_feats:
     assoc_skill: Nature
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Nature/trained
@@ -157,7 +157,7 @@ pf2e_feats:
     assoc_skill: Occultism
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Occultism/trained
@@ -168,7 +168,7 @@ pf2e_feats:
     assoc_skill: Performance
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Performance/trained
@@ -179,7 +179,7 @@ pf2e_feats:
     assoc_skill: Religion
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Religion/trained
@@ -190,7 +190,7 @@ pf2e_feats:
     assoc_skill: Society
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Society/trained
@@ -201,7 +201,7 @@ pf2e_feats:
     assoc_skill: Stealth
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Stealth/trained
@@ -212,7 +212,7 @@ pf2e_feats:
     assoc_skill: Survival
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Survival/trained
@@ -223,7 +223,7 @@ pf2e_feats:
     assoc_skill: Thievery
     traits:
     - fortune
-    shortdesc: Receive a fixed result on a skill check.
+    shortdesc: Even in the worst circumstances, you can perform basic tasks. Choose a skill you're trained in. You can forgo rolling a skill check for that skill to instead receive a result of 10 + your proficiency bonus (do not apply any other bonuses, penalties, or modifiers).%r%r**Special** You can select this feat multiple times. Each time, choose a different skill and gain the benefits for that skill.
     prereq:
       level: 1
       skill: Thievery/trained
@@ -235,13 +235,14 @@ pf2e_feats:
     traits:
     - healing
     - manipulate
-    shortdesc: Heal yourself or an ally in battle.
+    shortdesc: You can patch up wounds, even in combat. Attempt a Medicine check with the same DC as for Treat Wounds and restore the corresponding amount of HP; this doesn't remove the wounded condition. As with Treat Wounds, you can attempt checks against higher DCs if you have the minimum proficiency rank. The target is then temporarily immune to your Battle Medicine for 1 day.
     prereq:
       level: 1
       skill: Medicine/trained
   Bon Mot:
     feat_type: 
     - Skill
+    - General
     assoc_skill: Diplomacy
     traits:
     - auditory
@@ -250,7 +251,7 @@ pf2e_feats:
     - general
     - linguistic
     - mental
-    shortdesc: Distract a foe with a witty quip.
+    shortdesc: You launch an insightful quip at a foe, distracting them. Choose a foe within 30 feet and roll a Diplomacy check against the target's Will DC.%r%r**Critical Success** The target is distracted and takes a –3 status penalty to Perception and Will saves for 1 minute. The target can end the effect early with a retort to your Bon Mot. This can either be a single action that has the concentrate trait or an appropriate skill action to frame their retort. The GM determines which skill actions qualify, though they must take at least 1 action. Typically, the retort needs to use a linguistic Charisma-based skill action.%r**Success** As critical success, but the penalty is –2.%r**Critical Failure** Your quip is atrocious. You take the same penalty an enemy would take had you succeeded. This ends after 1 minute or if you issue another Bon Mot and succeed.
     prereq:
       level: 1
       skill: Diplomacy/trained
@@ -260,7 +261,7 @@ pf2e_feats:
     - General
     assoc_skill: Acrobatics
     traits: []
-    shortdesc: Treat falls as shorter than they are.
+    shortdesc: Your catlike aerial acrobatics allow you to cushion your falls. Treat falls as 10 feet shorter. If you're an expert in Acrobatics, treat falls as 25 feet shorter. If you're a master in Acrobatics, treat them as 50 feet shorter. If you're legendary in Acrobatics, you always land on your feet and don't take damage, regardless of the distance of the fall.
     prereq:
       level: 1
       skill: Acrobatics/trained
@@ -270,7 +271,7 @@ pf2e_feats:
     - Skill
     assoc_skill: Deception
     traits: []
-    shortdesc: Improve a target's attitude with your lies.
+    shortdesc: Your charm allows you to win over those you lie to. When you get a critical success using the Lie action, the target's attitude toward you improves by one step, as though you'd succeeded at using Diplomacy to Make an Impression. This works only once per conversation, and if you critically succeed against multiple targets using the same result, you choose one creature's attitude to improve. You must be lying to impart seemingly important information, inflate your status, or ingratiate yourself, which trivial or irrelevant lies can't achieve.
     prereq:
       level: 1
       skill: Deception/trained
@@ -280,7 +281,7 @@ pf2e_feats:
     - General
     assoc_skill: Athletics
     traits: []
-    shortdesc: Fight more effectively as you Climb.
+    shortdesc: Your techniques allow you to fight as you climb. You're not flat-footed while Climbing and can Climb with a hand occupied. You must still use another hand and both legs to Climb.
     prereq:
       level: 1
       skill: Athletics/trained
@@ -290,7 +291,7 @@ pf2e_feats:
     - General
     assoc_skill: Thievery
     traits: []
-    shortdesc: Conceal an Object using Thievery instead of Stealth.
+    shortdesc: Rather than hide an object somewhere the inspectors won't search, you're skilled at keeping the object on the move so it's never where they look. When you Conceal an Object of light Bulk or less, you can use Thievery instead of Stealth for your checks and for the DC of an active searcher's Perception check. You roll the check only once, but you must continue to use actions to Conceal an Object throughout the process.
     prereq:
       level: 1
       skill: Thievery/trained
@@ -300,7 +301,7 @@ pf2e_feats:
     - General
     assoc_skill: Society
     traits: []
-    shortdesc: Use Society to get along in noble society.
+    shortdesc: You were raised among the nobility or have learned proper etiquette and bearing, allowing you to present yourself as a noble and play games of influence and politics. You can use Society to Make an Impression on a noble, as well as with Impersonate to pretend to be a noble if you aren't one. If you want to impersonate a specific noble, you still need to use Deception to Impersonate normally, and to Lie when necessary.
     prereq:
       level: 1
       skill: Society/trained
@@ -310,7 +311,7 @@ pf2e_feats:
     - General
     assoc_skill: Crafting
     traits: []
-    shortdesc: Use Crafting to identify magic items.
+    shortdesc: Your knowledge of items' construction allows you to discern their magical effects as well. You can use Crafting instead of a skill associated with a magic tradition to Identify Magic on magic items, though not on any other sorts of magic.
     prereq:
       level: 1
       skill: Crafting/trained
@@ -320,7 +321,7 @@ pf2e_feats:
     - General
     assoc_skill: Occultism
     traits: []
-    shortdesc: Pass yourself off as a member of a religion.
+    shortdesc: Members of your cult frequently pass themselves off as worshippers of other religions. You can use Occultism instead of Deception to Impersonate a typical worshipper of another faith or to Lie specifically to claim you are a member of the faith you are Impersonating. You still need to use the Deception skill to Impersonate a specific worshipper or to perform other deceptive actions, such as attempting to Lie about any other matter.
     prereq:
       level: 1
       skill: Occultism/trained
@@ -330,7 +331,7 @@ pf2e_feats:
     - General
     assoc_skill: Arcana
     traits: []
-    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    shortdesc: You're a treasure trove of information, but not all of it comes from reputable sources. When you fail (but don't critically fail) a Recall Knowledge check using any skill, you learn a bit of true knowledge and a bit of erroneous knowledge, but you don't have any way to differentiate which is which.
     prereq:
       level: 1
       skill: Arcana/trained
@@ -340,7 +341,7 @@ pf2e_feats:
     - General
     assoc_skill: Crafting
     traits: []
-    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    shortdesc: You're a treasure trove of information, but not all of it comes from reputable sources. When you fail (but don't critically fail) a Recall Knowledge check using any skill, you learn a bit of true knowledge and a bit of erroneous knowledge, but you don't have any way to differentiate which is which.
     prereq:
       level: 1
       skill: Crafting/trained
@@ -350,7 +351,7 @@ pf2e_feats:
     - General
     assoc_skill: Medicine
     traits: []
-    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    shortdesc: You're a treasure trove of information, but not all of it comes from reputable sources. When you fail (but don't critically fail) a Recall Knowledge check using any skill, you learn a bit of true knowledge and a bit of erroneous knowledge, but you don't have any way to differentiate which is which.
     prereq:
       level: 1
       skill: Medicine/trained
@@ -360,7 +361,7 @@ pf2e_feats:
     - General
     assoc_skill: Nature
     traits: []
-    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    shortdesc: You're a treasure trove of information, but not all of it comes from reputable sources. When you fail (but don't critically fail) a Recall Knowledge check using any skill, you learn a bit of true knowledge and a bit of erroneous knowledge, but you don't have any way to differentiate which is which.
     prereq:
       level: 1
       skill: Nature/trained
@@ -370,7 +371,7 @@ pf2e_feats:
     - General
     assoc_skill: Occultism
     traits: []
-    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    shortdesc: You're a treasure trove of information, but not all of it comes from reputable sources. When you fail (but don't critically fail) a Recall Knowledge check using any skill, you learn a bit of true knowledge and a bit of erroneous knowledge, but you don't have any way to differentiate which is which.
     prereq:
       level: 1
       skill: Occultism/trained
@@ -380,7 +381,7 @@ pf2e_feats:
     - General
     assoc_skill: Religion
     traits: []
-    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    shortdesc: You're a treasure trove of information, but not all of it comes from reputable sources. When you fail (but don't critically fail) a Recall Knowledge check using any skill, you learn a bit of true knowledge and a bit of erroneous knowledge, but you don't have any way to differentiate which is which.
     prereq:
       level: 1
       skill: Religion/trained
@@ -390,7 +391,7 @@ pf2e_feats:
     - General
     assoc_skill: Society
     traits: []
-    shortdesc: Learn true and erroneous knowledge on failed Recall Knowledge check.
+    shortdesc: You're a treasure trove of information, but not all of it comes from reputable sources. When you fail (but don't critically fail) a Recall Knowledge check using any skill, you learn a bit of true knowledge and a bit of erroneous knowledge, but you don't have any way to differentiate which is which.
     prereq:
       level: 1
       skill: Society/trained
@@ -400,7 +401,7 @@ pf2e_feats:
     - General
     assoc_skill: Stealth
     traits: []
-    shortdesc: Conceal items from observers more effectively.
+    shortdesc: You often smuggle things past the authorities. When the GM rolls your Stealth check to see if a passive observer notices a small item you have concealed, the GM uses the number rolled or 10—whichever is higher—as the result of your die roll, adding it to your Stealth modifier to determine your Stealth check result. If you're a master in Stealth, the GM uses the number rolled or 15, and if you're legendary in Stealth, you automatically succeed at hiding a small concealed item from passive observers. This provides no benefits when a creature attempts a Perception check while actively searching you for hidden items.
     prereq:
       level: 1
       skill: Stealth/trained
@@ -410,7 +411,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: Track at your full Speed at a –5 penalty.
+    shortdesc: Tracking is second nature to you, and when necessary you can follow a trail without pause. You can Track while moving at full Speed by taking a –5 penalty to your Survival check. If you're a master in Survival, you don't take the –5 penalty. If you're legendary in Survival, you no longer need to roll a new Survival check every hour when tracking, though you still need to roll whenever there are significant changes in the trail.
     prereq:
       level: 1
       skill: Survival/trained
@@ -422,7 +423,7 @@ pf2e_feats:
     traits:
     - exploration
     - move
-    shortdesc: Increase your mount's travel speed.
+    shortdesc: You know how to encourage your mount to cover ground quickly. When calculating your travel speed for the day while mounted, you can attempt a Nature check to Command an Animal to increase your mount's travel speed. The DC is determined by the GM, but is typically based on the mount's level or the difficulty of the environment, whichever is harder. On a success, increase your mount's travel speed by half. This has no effect on your mount's movement in encounters.
     prereq:
       level: 1
       skill: Nature/trained
@@ -432,7 +433,7 @@ pf2e_feats:
     - General
     assoc_skill: Society
     traits: []
-    shortdesc: +2 to Decipher Writing about math and count items quickly.
+    shortdesc: You've learned to subitize, quickly estimating the number of items in a group with relative accuracy at only a glance. You immediately learn the number of visually similar items in a group you can see (such as coins, books, or people), rounded to the first digit in the total number. For example, you could look at a case of potion vials and learn that it held about 30 vials, but you wouldn't know that it was exactly 33 vials, how many different types of potions there were, or how many of which type. Similarly, you could look at a pile of 2,805 coins and know that there were about 3,000 coins in all. You can use this ability only on items that can typically be counted, so you can't use it on grains of sand or stars in the sky, for example.%r%rIn addition, when you attempt to Decipher Writing that is primarily numerical or mathematical, you gain a +2 circumstance bonus to your check.
     prereq:
       level: 1
       skill: Society/trained
@@ -442,7 +443,7 @@ pf2e_feats:
     - Skill
     assoc_skill: Performance
     traits: []
-    shortdesc: Perform to fascinate observers.
+    shortdesc: When you Perform, compare your result to the Will DC of one observer. If you succeed, the target is fascinated by you for 1 round. If the observer is in a situation that demands immediate attention, such as combat, you must critically succeed to fascinate it and the Perform action gains the incapacitation trait. You must choose which creature you're trying to fascinate before you roll your check, and the target is then temporarily immune for 1 hour. If you're an expert in Performance, you can fascinate up to four observers; if you're a master, you can fascinate up to 10 observers; and if you're legendary, you can fascinate any number of observers at the same time.
     prereq:
       level: 1
       skill: Performance/trained
@@ -452,7 +453,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: Forage for supplies to provide for multiple creatures.
+    shortdesc: While using Survival to Subsist, if you roll any result worse than a success, you get a success. On a success, you can provide subsistence living for yourself and four additional creatures, and on a critical success, you can take care of twice as many creatures as on a success.%r%rEach time your proficiency rank in Survival increases, double the number of additional creatures you can take care of on a success (to eight if you're an expert, 16 if you're a master, or 32 if you're legendary). You can choose to care for half the number of additional creatures and provide a comfortable living instead of subsistence living.%r%rMultiple smaller creatures or creatures with significantly smaller appetites than a human are counted as a single creature for this feat, and larger creatures or those with significantly greater appetites each count as multiple creatures. The GM determines how much a non-human creature needs to eat.
     prereq:
       level: 1
       skill: Survival/trained
@@ -462,7 +463,7 @@ pf2e_feats:
     - General
     assoc_skill: Medicine
     traits: []
-    shortdesc: Rapidly examine a body and Recall Knowledge about it.
+    shortdesc: You understand the principles of forensic medicine, making you better at examining a body to determine the cause of death or injury. You can perform a forensic examination on a body, as described under Recall Knowledge in the Medicine skill, in half the normal amount of time it would take (to a minimum of 5 minutes). If you succeed at your check, you can attempt an immediate check to Recall Knowledge to follow up on something you found, with a +2 circumstance bonus. This check is usually related to the cause of injury or death, such as a Crafting check to identify a poison or weapon that was used or an additional Medicine check to identify a specific disease. If you prefer, you can instead attempt to Recall Knowledge about the type of creature whose body you were examining, using the appropriate skill and gaining the same circumstance bonus.%r%rThe circumstance bonus increases to +3 if you have master proficiency in Medicine and +4 if you have legendary proficiency.
     prereq:
       level: 1
       skill: Medicine/trained
@@ -472,7 +473,7 @@ pf2e_feats:
     - General
     assoc_skill: Society
     traits: []
-    shortdesc: Decipher Writing even when you can’t see the document well.
+    shortdesc: You are adept at quickly scanning loose papers and carefully discerning the contents of sealed letters without damaging the seal. You can attempt Society checks to Decipher Writing on a message that is only partially glimpsed, upside down or reversed from your perspective, or even sealed. However, on a critical failure, the recipient is made aware of your efforts (for instance, you damage the seal or disturb the papers in some way). When using this feat to decipher sealed letters, your attempt to Decipher Writing gains the manipulate trait. This feat doesn't prevent witnesses from noticing your efforts, particularly with sealed letters which you must manipulate directly in order to read; you might need to attempt Deception or Stealth checks to avoid being noticed.
     prereq:
       level: 1
       skill: Society/trained
@@ -482,7 +483,7 @@ pf2e_feats:
     - General
     assoc_skill: Intimidation
     traits: []
-    shortdesc: Coerce multiple targets simultaneously.
+    shortdesc: When you Coerce, you can compare your Intimidation check result to the Will DCs of two targets instead of one. It's possible to get a different degree of success for each target. The number of targets you can Coerce in a single action increases to four if you're an expert, 10 if you're a master, and 25 if you're legendary.
     prereq:
       level: 1
       skill: Intimidation/trained
@@ -492,7 +493,7 @@ pf2e_feats:
     - General
     assoc_skill: Diplomacy
     traits: []
-    shortdesc: Make an Impression on multiple targets at once.
+    shortdesc: When you Make an Impression, you can compare your Diplomacy check result to the Will DCs of two targets instead of one. It's possible to get a different degree of success for each target. The number of targets increases to four if you're an expert, 10 if you're a master, and 25 if you're legendary.
     prereq:
       level: 1
       skill: Diplomacy/trained  
@@ -502,7 +503,7 @@ pf2e_feats:
     - General
     assoc_skill: Athletics
     traits: []
-    shortdesc: Increase your Bulk limits by 2.
+    shortdesc: You can carry more than your frame implies. Increase your maximum and encumbered Bulk limits by 2.
     prereq:
       level: 1
       skill: Athletics/trained
@@ -512,7 +513,7 @@ pf2e_feats:
     - General
     assoc_skill: Diplomacy
     traits: []
-    shortdesc: Gather Information rapidly.
+    shortdesc: You are skilled at learning information through conversation. The Gather Information exploration activity takes you half as long as normal (typically reducing the time to 1 hour). If you're a master in Diplomacy and you Gather Information at the normal speed, when you attempt to do so and roll a critical failure, you get a failure instead. There is still no guarantee that a rumor you learn with Gather Information is accurate.
     prereq:
       level: 1
       skill: Diplomacy/trained
@@ -522,7 +523,7 @@ pf2e_feats:
     - General
     assoc_skill: Performance
     traits: []
-    shortdesc: Make an Impression with Performance.
+    shortdesc: Your performances inspire admiration and win you fans. You can Make an Impression using Performance instead of Diplomacy.
     prereq:
       level: 1
       skill: Performance/trained
@@ -532,7 +533,7 @@ pf2e_feats:
     - General
     assoc_skill: Crafting
     traits: []
-    shortdesc: Craft basic tools without a basic crafter's book.
+    shortdesc: You can jury-rig solutions when you don't have the proper tools on hand. You can attempt to Repair damaged items without a repair kit.%r%rIf you have the raw materials available, you can Craft a basic caltrop set, candle, compass, crowbar, fishing tackle, flint and steel, hammer, ladder, piton, rope, 10-foot pole, replacement thieves' picks, long or short tool, or torch without consulting a basic crafter's book.
     prereq:
       level: 1
       skill: Crafting/trained
@@ -543,7 +544,7 @@ pf2e_feats:
     assoc_skill: Medicine
     traits:
     - healing
-    shortdesc: Grant patients +2 to saves against getting a disease again.
+    shortdesc: You have practice combating plague, and your patients are less likely to succumb to the same disease again for a time. When you successfully Treat Disease on someone and they fully recover from the disease, they gain a +2 circumstance bonus to saving throws against that same disease for 1 week.
     prereq:
       level: 1
       skill: Medicine/trained
@@ -553,7 +554,7 @@ pf2e_feats:
     - General
     assoc_skill: Intimidation
     traits: []
-    shortdesc: Demoralize a creature without speaking.
+    shortdesc: You can Demoralize with a mere glare. When you do, Demoralize loses the auditory trait and gains the visual trait, and you don't take a penalty if the creature doesn't understand your language.
     prereq:
       level: 1
       skill: Intimidation/trained
@@ -563,7 +564,17 @@ pf2e_feats:
     - General
     assoc_skill: Deception
     traits: []
-    shortdesc: Remain hidden after you Create a Diversion.
+    shortdesc: When you critically succeed to Create a Diversion, you continue to remain hidden after the end of your turn. This effect lasts for an amount of time that depends on the diversion and situation, as determined by the GM (minimum 1 additional round).
+    prereq:
+      level: 1
+      skill: Deception/trained
+  Lie to Me:
+    feat_type:
+    - Skill
+    - General
+    assoc_skill: Deception
+    traits: []
+    shortdesc: You can use Deception to weave traps to trip up anyone trying to deceive you. If you can engage in conversation with someone trying to Lie to you, use your Deception DC if it is higher than your Perception DC to determine whether they succeed. This doesn't apply if you don't have a back-and-forth dialogue, such as when someone attempts to Lie during a long speech.
     prereq:
       level: 1
       skill: Deception/trained
@@ -573,7 +584,7 @@ pf2e_feats:
     - General
     assoc_skill: Society
     traits: []
-    shortdesc: Learn two new languages.
+    shortdesc: You easily pick up new languages. You learn two new languages, chosen from common languages, uncommon languages, and any others you have access to. You learn an additional language if you are or become a master in Society and again if you are or become legendary.%r%r**Special** You can select this feat multiple times. Each time, you learn additional languages.
     prereq:
       level: 1
       skill: Society/trained
@@ -583,7 +594,7 @@ pf2e_feats:
     - General
     assoc_skill: Nature
     traits: []
-    shortdesc: Use Nature to Treat Wounds.
+    shortdesc: You can apply natural cures to heal your allies. You can use Nature instead of Medicine to Treat Wounds. If you're in the wilderness, you might have easier access to fresh ingredients, allowing you to gain a +2 circumstance bonus to your check to Treat Wounds using Nature, subject to the GM's determination.
     prereq:
       level: 1
       skill: Nature/trained
@@ -599,7 +610,7 @@ pf2e_feats:
     - general
     - linguistic
     - mental
-    shortdesc: 'Reduce creatures’ frightened condition values.'
+    shortdesc: You attempt to reduce panic. Attempt a Diplomacy check, comparing it to the Will DC of creatures in a 10-foot emanation around you who are frightened. Each of them is temporarily immune for 1 hour.%r%r**Critical Success** Reduce the creature's frightened value by 2.%r**Success** Reduce the creature's frightened value by 1.
     prereq:
       level: 1
       skill: Diplomacy/trained
@@ -609,7 +620,7 @@ pf2e_feats:
     - General
     assoc_skill: Occultism
     traits: []
-    shortdesc: +2 to Occultism checks to Identify Magic with certain traits.
+    shortdesc: You have a sense for spells that twist minds or reveal secrets. You gain a +2 circumstance bonus to Occultism checks to Identify Magic with the mental, possession, prediction, or scrying traits.
     prereq:
       level: 1
       skill: Occultism/trained
@@ -619,7 +630,7 @@ pf2e_feats:
     - General
     assoc_skill: Thievery
     traits: []
-    shortdesc: Steal or Palm an Object more effectively.
+    shortdesc: You can Steal or Palm an Object that's closely guarded, such as in a pocket, without taking the –5 penalty. You can't steal objects that would be extremely noticeable or time consuming to remove (like worn shoes or armor or actively wielded objects). If you're a master in Thievery, you can attempt to Steal from a creature in combat or otherwise on guard. When doing so, Stealing requires 2 manipulate actions instead of 1, and you take a –5 penalty.
     prereq:
       level: 1
       skill: Thievery/trained
@@ -629,7 +640,7 @@ pf2e_feats:
     - General
     assoc_skill: Religion
     traits: []
-    shortdesc: A religious token lets you act ﬁrst on a tie for initiative.
+    shortdesc: You carry a small token of protection from a site holy to your faith, or you touched your religious symbol to a relic or altar at such a site. So long as this token is in your possession, when you tie an adversary's initiative roll, you go first.%r%r**Special** If you select this feat at 1st level, you receive your pilgrim's token for free. Alternately, if you have a religious symbol, it is already attuned, as described above.%r%rIf you select this feat at a later level, or if you lose your pilgrim's token, you must purchase or Craft a replacement and attune it at a holy site. Such a token usually costs at least 2 sp, and the attunement takes 10 minutes of prayer and requires a successful DC 20 Religion check. Your GM might adjust the price and DC depending on the token's material and quality and the religious significance of the site; the more significant the location, the easier the attunement.
     prereq:
       level: 1
       skill: Religion/trained
@@ -639,7 +650,7 @@ pf2e_feats:
     - General
     assoc_skill: Intimidation
     traits: []
-    shortdesc: Coerce a creature quickly.
+    shortdesc: You can bully others with just a few choice implications. You can Coerce a creature after 1 round of conversation instead of 1 minute. You still can't Coerce a creature in the midst of combat, or without engaging in a conversation.
     prereq:
       level: 1
       skill: Intimidation/trained
@@ -649,7 +660,7 @@ pf2e_feats:
     - General
     assoc_skill: Arcana
     traits: []
-    shortdesc: Identify Magic in 1 minute or less.
+    shortdesc: You can Identify Magic swiftly. You take only 1 minute when using Identify Magic to determine the properties of an item, ongoing effect, or location, rather than 10 minutes. If you're a master, it takes a 3-action activity, and if you're legendary, it takes 1 action.
     prereq:
       level: 1
       skill: Arcana/trained
@@ -659,7 +670,7 @@ pf2e_feats:
     - General
     assoc_skill: Religion
     traits: []
-    shortdesc: Identify Magic in 1 minute or less.
+    shortdesc: You can Identify Magic swiftly. You take only 1 minute when using Identify Magic to determine the properties of an item, ongoing effect, or location, rather than 10 minutes. If you're a master, it takes a 3-action activity, and if you're legendary, it takes 1 action.
     prereq:
       level: 1
       skill: Religion/trained
@@ -669,7 +680,7 @@ pf2e_feats:
     - General
     assoc_skill: Occultism
     traits: []
-    shortdesc: Identify Magic in 1 minute or less.
+    shortdesc: You can Identify Magic swiftly. You take only 1 minute when using Identify Magic to determine the properties of an item, ongoing effect, or location, rather than 10 minutes. If you're a master, it takes a 3-action activity, and if you're legendary, it takes 1 action.
     prereq:
       level: 1
       skill: Occultism/trained
@@ -679,7 +690,7 @@ pf2e_feats:
     - General
     assoc_skill: Nature
     traits: []
-    shortdesc: Identify Magic in 1 minute or less.
+    shortdesc: You can Identify Magic swiftly. You take only 1 minute when using Identify Magic to determine the properties of an item, ongoing effect, or location, rather than 10 minutes. If you're a master, it takes a 3-action activity, and if you're legendary, it takes 1 action.
     prereq:
       level: 1
       skill: Nature/trained
@@ -689,7 +700,7 @@ pf2e_feats:
     - General
     assoc_skill: Athletics
     traits: []
-    shortdesc: High Jump or Long Jump as a single action.
+    shortdesc: You can use High Jump and Long Jump as a single action instead of 2 actions. If you do, you don't perform the initial Stride (nor do you fail if you don't Stride 10 feet).
     prereq:
       level: 1
       skill: Athletics/trained
@@ -699,7 +710,7 @@ pf2e_feats:
     - General
     assoc_skill: Crafting
     traits: []
-    shortdesc: Repair items quickly.
+    shortdesc: You take 1 minute to Repair an item. If you're a master in Crafting, it takes 3 actions. If you're legendary, it takes 1 action.
     prereq:
       level: 1
       skill: Crafting/trained
@@ -709,7 +720,7 @@ pf2e_feats:
     - General
     assoc_skill: Acrobatics
     traits: []
-    shortdesc: Move swiftly as you Squeeze.
+    shortdesc: You Squeeze 5 feet per round (10 feet on a critical success). If you're legendary in Acrobatics, you Squeeze at full Speed.
     prereq:
       level: 1
       skill: Acrobatics/trained  
@@ -719,7 +730,7 @@ pf2e_feats:
     - General
     assoc_skill: Society
     traits: []
-    shortdesc: Read the lips of people you can see.
+    shortdesc: You can read lips of others nearby who you can clearly see. When you're at your leisure, you can do this automatically. In encounter mode or when attempting a more difficult feat of lipreading, you're fascinated and flat-footed during each round in which you focus on lip movements, and you must succeed at a Society check (DC determined by the GM) to successfully read someone's lips. In either case, the language read must be one that you know.
     prereq:
       level: 1
       skill: Society/trained  
@@ -729,7 +740,7 @@ pf2e_feats:
     - General
     assoc_skill: Arcana
     traits: []
-    shortdesc: Identify a spell as a reaction as it's being cast.
+    shortdesc: If you are trained in the appropriate skill for the spell's tradition and it's a common spell of 2nd level or lower, you automatically identify it (you still roll to attempt to get a critical success, but can't get a worse result than success). The highest level of spell you automatically identify increases to 4 if you're an expert, 6 if you're a master, and 10 if you're legendary. The GM rolls a secret Arcana, Nature, Occultism, or Religion check, whichever corresponds to the tradition of the spell being cast. If you're not trained in the skill, you can't get a result better than failure.%r%r**Critical Success** You correctly recognize the spell and gain a +1 circumstance bonus to your saving throw or your AC against it.%r**Success** You correctly recognize the spell.%r**Failure** You fail to recognize the spell.%r**Critical Failure** You misidentify the spell as another spell entirely, of the GM's choice.
     prereq:
       level: 1
       skill: Arcana/trained
@@ -739,7 +750,7 @@ pf2e_feats:
     - General
     assoc_skill: Religion
     traits: []
-    shortdesc: Identify a spell as a reaction as it's being cast.
+    shortdesc: If you are trained in the appropriate skill for the spell's tradition and it's a common spell of 2nd level or lower, you automatically identify it (you still roll to attempt to get a critical success, but can't get a worse result than success). The highest level of spell you automatically identify increases to 4 if you're an expert, 6 if you're a master, and 10 if you're legendary. The GM rolls a secret Arcana, Nature, Occultism, or Religion check, whichever corresponds to the tradition of the spell being cast. If you're not trained in the skill, you can't get a result better than failure.%r%r**Critical Success** You correctly recognize the spell and gain a +1 circumstance bonus to your saving throw or your AC against it.%r**Success** You correctly recognize the spell.%r**Failure** You fail to recognize the spell.%r**Critical Failure** You misidentify the spell as another spell entirely, of the GM's choice.
     prereq:
       level: 1
       skill: Religion/trained
@@ -749,7 +760,7 @@ pf2e_feats:
     - General
     assoc_skill: Occultism
     traits: []
-    shortdesc: Identify a spell as a reaction as it's being cast.
+    shortdesc: If you are trained in the appropriate skill for the spell's tradition and it's a common spell of 2nd level or lower, you automatically identify it (you still roll to attempt to get a critical success, but can't get a worse result than success). The highest level of spell you automatically identify increases to 4 if you're an expert, 6 if you're a master, and 10 if you're legendary. The GM rolls a secret Arcana, Nature, Occultism, or Religion check, whichever corresponds to the tradition of the spell being cast. If you're not trained in the skill, you can't get a result better than failure.%r%r**Critical Success** You correctly recognize the spell and gain a +1 circumstance bonus to your saving throw or your AC against it.%r**Success** You correctly recognize the spell.%r**Failure** You fail to recognize the spell.%r**Critical Failure** You misidentify the spell as another spell entirely, of the GM's choice.
     prereq:
       level: 1
       skill: Occultism/trained
@@ -760,7 +771,7 @@ pf2e_feats:
     assoc_skill: Nature
     traits:
     - secret
-    shortdesc: Identify a spell as a reaction as it's being cast.
+    shortdesc: If you are trained in the appropriate skill for the spell's tradition and it's a common spell of 2nd level or lower, you automatically identify it (you still roll to attempt to get a critical success, but can't get a worse result than success). The highest level of spell you automatically identify increases to 4 if you're an expert, 6 if you're a master, and 10 if you're legendary. The GM rolls a secret Arcana, Nature, Occultism, or Religion check, whichever corresponds to the tradition of the spell being cast. If you're not trained in the skill, you can't get a result better than failure.%r%r**Critical Success** You correctly recognize the spell and gain a +1 circumstance bonus to your saving throw or your AC against it.%r**Success** You correctly recognize the spell.%r**Failure** You fail to recognize the spell.%r**Critical Failure** You misidentify the spell as another spell entirely, of the GM's choice.
     prereq:
       level: 1
       skill: Nature/trained
@@ -770,7 +781,7 @@ pf2e_feats:
     - General
     assoc_skill: Medicine
     traits: []
-    shortdesc: Deal damage to a patient to gain +2 to Treat Wounds.
+    shortdesc: Your surgery can bring a patient back from the brink of death, but might push them over the edge. When you Treat Wounds, you can deal 1d8 slashing damage to your patient just before applying the effects of Treat Wounds. If you do, you gain a +2 circumstance bonus to your Medicine check to Treat Wounds, and if you roll a success, you get a critical success instead.
     prereq:
       level: 1
       skill: Medicine/trained
@@ -780,7 +791,7 @@ pf2e_feats:
     - General
     assoc_skill: Occultism
     traits: []
-    shortdesc: Create a token that grants a bonus against a spell or haunt.
+    shortdesc: Your talismans ward against foul magic. During your daily preparations, you can assemble a small pouch with bits of herbs, hair, sacred oils, and other ritual ingredients, which you give to one ally. The first time that day the ally attempts a saving throw against a spell or haunt, they gain a +1 circumstance bonus to the roll. This bonus increases to +2 if you're an expert in Occultism or +3 if you're legendary.
     prereq:
       level: 1
       skill: Occultism/trained
@@ -790,7 +801,7 @@ pf2e_feats:
     - General
     assoc_skill: Occultism
     traits: []
-    shortdesc: Gather Information about secret societies and mystery cults.
+    shortdesc: You notice the signs and symbols that members of mystery cults and other secret societies use to declare their affiliation to fellow members. You can use Occultism in place of Diplomacy to Gather Information about such groups. If you belong to a secret cult, lodge, sect, or similar organization, you automatically recognize members of your group unless they are specifically attempting to conceal their presence from you.
     prereq:
       level: 1
       skill: Occultism/trained
@@ -800,7 +811,7 @@ pf2e_feats:
     - General
     assoc_skill: Crafting
     traits: []
-    shortdesc: +1 to Craft food and drink, including potions.
+    shortdesc: You've mastered the preparation of many types of food and drink. You gain a +1 circumstance bonus to checks to Craft food and drink, including potions. If you are a master in one of the prerequisite skills, this bonus increases to +2.
     prereq:
       level: 1
       orskill: 
@@ -812,7 +823,7 @@ pf2e_feats:
     - General
     - Skill
     traits: []
-    shortdesc: Become trained in a skill.
+    shortdesc: You become trained in the skill of your choice.%r%r**Special** You can select this feat multiple times, choosing a new skill to become trained in each time.
     prereq:
       level: 1
       ability: 
@@ -823,7 +834,7 @@ pf2e_feats:
     - General
     assoc_skill: Crafting
     traits: []
-    shortdesc: Craft snares.
+    shortdesc: You can use the Craft activity to create snares. When you select this feat, you add the formulas for four common snares to your formula book.
     prereq:
       level: 1
       skill: Crafting/trained
@@ -833,7 +844,7 @@ pf2e_feats:
     - General
     assoc_skill: Crafting
     traits: []
-    shortdesc: Gain bonuses to Craft certain items.
+    shortdesc: Your training focused on Crafting one particular kind of item. Select one of the specialties listed below; you gain a +1 circumstance bonus to Crafting checks to Craft items of that type. If you are a master in Crafting, this bonus increases to +2. If it's unclear whether the specialty applies, the GM decides. Some specialties might apply only partially. For example, if you were making a morningstar and had specialty in woodworking, the GM might give you half your bonus because the item requires both blacksmithing and woodworking.%r%rYou must have the Alchemical Crafting skill feat to Craft alchemical items.
     prereq:
       level: 1
       skill: Crafting/trained
@@ -843,7 +854,7 @@ pf2e_feats:
     - General
     assoc_skill: Acrobatics
     traits: []
-    shortdesc: Maintain your balance in adverse conditions.
+    shortdesc: You can keep your balance easily, even in adverse conditions. Whenever you roll a success using the Balance action, you get a critical success instead. You're not flat-footed while attempting to Balance on narrow surfaces and uneven ground. Thanks to your incredible balance, you can attempt an Acrobatics check instead of a Reflex save to Grab an Edge.
     prereq:
       level: 1
       skill: Acrobatics/trained
@@ -853,7 +864,7 @@ pf2e_feats:
     - General
     assoc_skill: Society
     traits: []
-    shortdesc: Use Society to Gather Information and Recall Knowledge.
+    shortdesc: You know about life on the streets and feel the pulse of your local settlement. You can use your Society modifier instead of your Diplomacy modifier to Gather Information. In any settlement you frequent regularly, you can use the Recall Knowledge action with Society to know the same sorts of information that you could discover with Diplomacy to Gather Information. The DC is usually significantly higher, but you know the information without spending time gathering it. If you fail to recall the information, you can still subsequently attempt to Gather Information normally.
     prereq:
       level: 1
       skill: Society/trained
@@ -863,7 +874,7 @@ pf2e_feats:
     - General
     assoc_skill: Religion
     traits: []
-    shortdesc: More accurately recognize the tenets of your faith or philosophy.
+    shortdesc: You've researched many faiths enough to recognize notions about them that are unlikely to be true. If you roll a critical failure at a Religion check to Decipher Writing of a religious nature or to Recall Knowledge about the tenets of faiths, you get a failure instead. When attempting to Recall Knowledge about the tenets of your own faith, if you roll a failure, you get a success instead, and if you roll a success, you get a critical success instead.
     prereq:
       level: 1
       skill: Religion/trained
@@ -873,7 +884,7 @@ pf2e_feats:
     - General
     assoc_skill: Thievery
     traits: []
-    shortdesc: Your thefts are harder to notice.
+    shortdesc: When you successfully Steal something, observers (creatures other than the creature you stole from) take a –2 circumstance penalty to their Perception DCs to detect your theft. Additionally, if you first Create a Diversion using Deception, taking a single Palm an Object or Steal action doesn't end your undetected condition.
     prereq:
       level: 1
       skill: Thievery/trained
@@ -883,7 +894,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: Identify nearby creatures through signs and clues.
+    shortdesc: You can study details in the wilderness to determine the presence of nearby creatures. You can spend 10 minutes assessing the area around you to find out what creatures are nearby, based on nests, scat, and marks on vegetation. Attempt a Survival check against a DC determined by the GM based on how obvious the signs are. On a success, you can attempt a Recall Knowledge check with a –2 penalty to learn more about the creatures just from these signs. If you're a master in Survival, you don't take the penalty.
     prereq:
       level: 1
       skill: Survival/trained
@@ -893,7 +904,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: +1 to Survival checks in certain terrain.
+    shortdesc: "Your experience in navigating a certain type of terrain makes you supremely confident while doing so. You gain a +1 circumstance bonus to Survival checks in one of the following types of terrain, chosen when you select this feat: aquatic, arctic, desert, forest, mountain, plains, sky, swamp, or underground.%r%r**Special** You can select this feat more than once, choosing a different type of terrain each time."
     prereq:
       level: 1
       skill: Survival/trained
@@ -903,7 +914,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: +1 to Survival checks in certain terrain.
+    shortdesc: "Your experience in navigating a certain type of terrain makes you supremely confident while doing so. You gain a +1 circumstance bonus to Survival checks in one of the following types of terrain, chosen when you select this feat: aquatic, arctic, desert, forest, mountain, plains, sky, swamp, or underground.%r%r**Special** You can select this feat more than once, choosing a different type of terrain each time."
     prereq:
       level: 1
       skill: Survival/trained
@@ -913,7 +924,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: +1 to Survival checks in certain terrain.
+    shortdesc: "Your experience in navigating a certain type of terrain makes you supremely confident while doing so. You gain a +1 circumstance bonus to Survival checks in one of the following types of terrain, chosen when you select this feat: aquatic, arctic, desert, forest, mountain, plains, sky, swamp, or underground.%r%r**Special** You can select this feat more than once, choosing a different type of terrain each time."
     prereq:
       level: 1
       skill: Survival/trained
@@ -923,7 +934,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: +1 to Survival checks in certain terrain.
+    shortdesc: "Your experience in navigating a certain type of terrain makes you supremely confident while doing so. You gain a +1 circumstance bonus to Survival checks in one of the following types of terrain, chosen when you select this feat: aquatic, arctic, desert, forest, mountain, plains, sky, swamp, or underground.%r%r**Special** You can select this feat more than once, choosing a different type of terrain each time."
     prereq:
       level: 1
       skill: Survival/trained
@@ -933,7 +944,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: +1 to Survival checks in certain terrain.
+    shortdesc: "Your experience in navigating a certain type of terrain makes you supremely confident while doing so. You gain a +1 circumstance bonus to Survival checks in one of the following types of terrain, chosen when you select this feat: aquatic, arctic, desert, forest, mountain, plains, sky, swamp, or underground.%r%r**Special** You can select this feat more than once, choosing a different type of terrain each time."
     prereq:
       level: 1
       skill: Survival/trained
@@ -943,7 +954,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: +1 to Survival checks in certain terrain.
+    shortdesc: "Your experience in navigating a certain type of terrain makes you supremely confident while doing so. You gain a +1 circumstance bonus to Survival checks in one of the following types of terrain, chosen when you select this feat: aquatic, arctic, desert, forest, mountain, plains, sky, swamp, or underground.%r%r**Special** You can select this feat more than once, choosing a different type of terrain each time."
     prereq:
       level: 1
       skill: Survival/trained
@@ -953,7 +964,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: +1 to Survival checks in certain terrain.
+    shortdesc: "Your experience in navigating a certain type of terrain makes you supremely confident while doing so. You gain a +1 circumstance bonus to Survival checks in one of the following types of terrain, chosen when you select this feat: aquatic, arctic, desert, forest, mountain, plains, sky, swamp, or underground.%r%r**Special** You can select this feat more than once, choosing a different type of terrain each time."
     prereq:
       level: 1
       skill: Survival/trained
@@ -963,7 +974,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: +1 to Survival checks in certain terrain.
+    shortdesc: "Your experience in navigating a certain type of terrain makes you supremely confident while doing so. You gain a +1 circumstance bonus to Survival checks in one of the following types of terrain, chosen when you select this feat: aquatic, arctic, desert, forest, mountain, plains, sky, swamp, or underground.%r%r**Special** You can select this feat more than once, choosing a different type of terrain each time."
     prereq:
       level: 1
       skill: Survival/trained
@@ -973,7 +984,7 @@ pf2e_feats:
     - General
     assoc_skill: Survival
     traits: []
-    shortdesc: +1 to Survival checks in certain terrain.
+    shortdesc: "Your experience in navigating a certain type of terrain makes you supremely confident while doing so. You gain a +1 circumstance bonus to Survival checks in one of the following types of terrain, chosen when you select this feat: aquatic, arctic, desert, forest, mountain, plains, sky, swamp, or underground.%r%r**Special** You can select this feat more than once, choosing a different type of terrain each time."
     prereq:
       level: 1
       skill: Survival/trained
@@ -983,7 +994,7 @@ pf2e_feats:
     - General
     assoc_skill: Stealth
     traits: []
-    shortdesc: Sneak in certain terrain without attempting a check.
+    shortdesc: "Select one type of difficult terrain from the following list: rubble, snow, or underbrush. While undetected by all non-allies in that type of terrain, you can Sneak without attempting a Stealth check as long as you move no more than 5 feet and do not move within 10 feet of an enemy at any point during your movement. This also allows you to automatically approach creatures to within 15 feet while Avoiding Notice during exploration as long as they aren't actively Searching or on guard.%r%r**Special** You can select this feat multiple times. Each time, choose a different type of terrain."
     prereq:
       level: 1
       skill: Stealth/trained
@@ -993,7 +1004,7 @@ pf2e_feats:
     - General
     assoc_skill: Athletics
     traits: []
-    shortdesc: Disarm, Grapple, Shove, or Trip larger creatures.
+    shortdesc: You can attempt to Disarm, Grapple, Shove, or Trip creatures up to two sizes larger than you, or up to three sizes larger than you if you're legendary in Athletics.
     prereq:
       level: 1
       skill: Athletics/trained
@@ -1005,7 +1016,7 @@ pf2e_feats:
     traits:
     - downtime
     - manipulate
-    shortdesc: Teach an animal a trick.
+    shortdesc: You spend time teaching an animal to do a certain action. You can either select a basic action the animal already knows how to do (typically those listed in the Command an Animal action) or attempt to teach the animal a new basic action. The GM determines the DC of any check required and the amount of time the training takes (usually at least a week). It's usually impossible to teach an animal a trick that uses critical thinking. If you're expert, master, or legendary in Nature, you might be able to train more unusual creatures, at the GM's discretion.%r%r**Success** The animal learns the action. If it was an action the animal already knew, you can Command the Animal to take that action without attempting a Nature check. If it was a new basic action, add that action to the actions the animal can take when Commanded, but you must still roll.%r**Failure** The animal doesn't learn the trick.
     prereq:
       level: 1
       skill: Nature/trained  
@@ -1014,8 +1025,9 @@ pf2e_feats:
     - Skill
     - General
     assoc_skill: Arcana
-    traits: []
-    shortdesc: Activate a magic item you normally can't activate.
+    traits:
+    - manipulate
+    shortdesc: You examine a magic item you normally couldn't use in an effort to fool it and activate it temporarily. For example, this might allow a fighter to cast a spell from a wand or allow a wizard to cast a spell that's not on the arcane list using a scroll. You must know what activating the item does, or you can't attempt to trick it.%r%rAttempt a check using the skill matching the item's magic tradition, or matching a tradition that has the spell on its list, if you're trying to cast a spell from the item. The relevant skills are Arcana for arcane, Nature for primal, Occultism for occult, Religion for divine, or any of the four for an item that has the magical trait and not a tradition trait. The GM determines the DC based on the item's level (possibly adjusted depending on the item or situation).%r%rIf you activate a magic item that requires a spell attack roll or spell DC and you don't have the ability to cast spells of the relevant tradition, use your level as your proficiency bonus and the highest of your Intelligence, Wisdom, or Charisma modifiers. If you're a master in the appropriate skill for the item's tradition, you instead use the trained proficiency bonus, and if you're legendary, you instead use the expert proficiency bonus.%r%r**Success** For the rest of the current turn, you can spend actions to activate the item as if you could normally use it.%r**Failure** You can't use the item or try to trick it again this turn, but you can try again on subsequent turns.%r**Critical Failure** You can't use the item, and you can't try to trick it again until your next daily preparations.
     prereq:
       level: 1
       skill: Arcana/trained
@@ -1024,8 +1036,9 @@ pf2e_feats:
     - Skill
     - General
     assoc_skill: Religion
-    traits: []
-    shortdesc: Activate a magic item you normally can't activate.
+    traits:
+    - manipulate
+    shortdesc: You examine a magic item you normally couldn't use in an effort to fool it and activate it temporarily. For example, this might allow a fighter to cast a spell from a wand or allow a wizard to cast a spell that's not on the arcane list using a scroll. You must know what activating the item does, or you can't attempt to trick it.%r%rAttempt a check using the skill matching the item's magic tradition, or matching a tradition that has the spell on its list, if you're trying to cast a spell from the item. The relevant skills are Arcana for arcane, Nature for primal, Occultism for occult, Religion for divine, or any of the four for an item that has the magical trait and not a tradition trait. The GM determines the DC based on the item's level (possibly adjusted depending on the item or situation).%r%rIf you activate a magic item that requires a spell attack roll or spell DC and you don't have the ability to cast spells of the relevant tradition, use your level as your proficiency bonus and the highest of your Intelligence, Wisdom, or Charisma modifiers. If you're a master in the appropriate skill for the item's tradition, you instead use the trained proficiency bonus, and if you're legendary, you instead use the expert proficiency bonus.%r%r**Success** For the rest of the current turn, you can spend actions to activate the item as if you could normally use it.%r**Failure** You can't use the item or try to trick it again this turn, but you can try again on subsequent turns.%r**Critical Failure** You can't use the item, and you can't try to trick it again until your next daily preparations.
     prereq:
       level: 1
       skill: Religion/trained
@@ -1034,8 +1047,9 @@ pf2e_feats:
     - Skill
     - General
     assoc_skill: Occutltism
-    traits: []
-    shortdesc: Activate a magic item you normally can't activate.
+    traits:
+    - manipulate
+    shortdesc: You examine a magic item you normally couldn't use in an effort to fool it and activate it temporarily. For example, this might allow a fighter to cast a spell from a wand or allow a wizard to cast a spell that's not on the arcane list using a scroll. You must know what activating the item does, or you can't attempt to trick it.%r%rAttempt a check using the skill matching the item's magic tradition, or matching a tradition that has the spell on its list, if you're trying to cast a spell from the item. The relevant skills are Arcana for arcane, Nature for primal, Occultism for occult, Religion for divine, or any of the four for an item that has the magical trait and not a tradition trait. The GM determines the DC based on the item's level (possibly adjusted depending on the item or situation).%r%rIf you activate a magic item that requires a spell attack roll or spell DC and you don't have the ability to cast spells of the relevant tradition, use your level as your proficiency bonus and the highest of your Intelligence, Wisdom, or Charisma modifiers. If you're a master in the appropriate skill for the item's tradition, you instead use the trained proficiency bonus, and if you're legendary, you instead use the expert proficiency bonus.%r%r**Success** For the rest of the current turn, you can spend actions to activate the item as if you could normally use it.%r**Failure** You can't use the item or try to trick it again this turn, but you can try again on subsequent turns.%r**Critical Failure** You can't use the item, and you can't try to trick it again until your next daily preparations.
     prereq:
       level: 1
       skill: Occultism/trained
@@ -1044,8 +1058,9 @@ pf2e_feats:
     - Skill
     - General
     assoc_skill: Nature
-    traits: []
-    shortdesc: Activate a magic item you normally can't activate.
+    traits:
+    - manipulate
+    shortdesc: You examine a magic item you normally couldn't use in an effort to fool it and activate it temporarily. For example, this might allow a fighter to cast a spell from a wand or allow a wizard to cast a spell that's not on the arcane list using a scroll. You must know what activating the item does, or you can't attempt to trick it.%r%rAttempt a check using the skill matching the item's magic tradition, or matching a tradition that has the spell on its list, if you're trying to cast a spell from the item. The relevant skills are Arcana for arcane, Nature for primal, Occultism for occult, Religion for divine, or any of the four for an item that has the magical trait and not a tradition trait. The GM determines the DC based on the item's level (possibly adjusted depending on the item or situation).%r%rIf you activate a magic item that requires a spell attack roll or spell DC and you don't have the ability to cast spells of the relevant tradition, use your level as your proficiency bonus and the highest of your Intelligence, Wisdom, or Charisma modifiers. If you're a master in the appropriate skill for the item's tradition, you instead use the trained proficiency bonus, and if you're legendary, you instead use the expert proficiency bonus.%r%r**Success** For the rest of the current turn, you can spend actions to activate the item as if you could normally use it.%r**Failure** You can't use the item or try to trick it again this turn, but you can try again on subsequent turns.%r**Critical Failure** You can't use the item, and you can't try to trick it again until your next daily preparations.
     prereq:
       level: 1
       skill: Nature/trained
@@ -1055,7 +1070,7 @@ pf2e_feats:
     - General
     assoc_skill: Athletics
     traits: []
-    shortdesc: Fight more effectively underwater.
+    shortdesc: You've learned to fight underwater. You are not flat-footed while in water, and you don't take the usual penalties for using a bludgeoning or slashing melee weapon in water.
     prereq:
       level: 1
       skill: Athletics/trained
@@ -1065,7 +1080,7 @@ pf2e_feats:
     - General
     assoc_skill: Performance
     traits: []
-    shortdesc: +1 with a certain type of performance.
+    shortdesc: You have exceptional talent with one type of performance. You gain a +1 circumstance bonus when making a certain type of performance. If you are a master in Performance, this bonus increases to +2. Select one of the following specialties and apply the bonus when attempting Performance checks of that type. If it's unclear whether the specialty applies, the GM decides.
     prereq:
       level: 1
       skill: Performance/trained
@@ -1076,7 +1091,7 @@ pf2e_feats:
     - General
     assoc_skill: Stealth
     traits: []
-    shortdesc: Reduce the Stealth penalty of your armor.
+    shortdesc: You have learned techniques to adjust and modify your armor and movements to reduce the noise you make. When you wear non-noisy armor with which you are trained, your penalty to Stealth checks is reduced by 1 (to a minimum penalty of 0). If you're a master in Stealth, reduce the penalty by 2, and if you're legendary, reduce the penalty by 3. If your armor has the noisy trait, instead of reducing the penalty to Stealth checks, you ignore the effects of the noisy trait, enabling you to remove the penalty with a sufficient Strength score as normal.
     prereq:
       level: 2
       skill: Stealth/expert
@@ -1086,7 +1101,7 @@ pf2e_feats:
     - General
     assoc_skill: Arcana
     traits: []
-    shortdesc: Avoid misidentifying magic.
+    shortdesc: You rarely misidentify an item. When using Arcana, Nature, Occultism, or Religion checks to Identify Magic, if you roll a critical failure, you get a failure instead. If you would misidentify a cursed item because you roll a success but not a critical success, you simply can't identify it instead.
     prereq:
       level: 2
       skill: Arcana/expert
@@ -1096,7 +1111,7 @@ pf2e_feats:
     - General
     assoc_skill: Religion
     traits: []
-    shortdesc: Avoid misidentifying magic.
+    shortdesc: You rarely misidentify an item. When using Arcana, Nature, Occultism, or Religion checks to Identify Magic, if you roll a critical failure, you get a failure instead. If you would misidentify a cursed item because you roll a success but not a critical success, you simply can't identify it instead.
     prereq:
       level: 2
       skill: Divine/expert
@@ -1106,7 +1121,7 @@ pf2e_feats:
     - General
     assoc_skill: Nature
     traits: []
-    shortdesc: Avoid misidentifying magic.
+    shortdesc: You rarely misidentify an item. When using Arcana, Nature, Occultism, or Religion checks to Identify Magic, if you roll a critical failure, you get a failure instead. If you would misidentify a cursed item because you roll a success but not a critical success, you simply can't identify it instead.
     prereq:
       level: 2
       skill: Nature/expert
@@ -1116,7 +1131,7 @@ pf2e_feats:
     - General
     assoc_skill: Occultism
     traits: []
-    shortdesc: Avoid misidentifying magic.
+    shortdesc: You rarely misidentify an item. When using Arcana, Nature, Occultism, or Religion checks to Identify Magic, if you roll a critical failure, you get a failure instead. If you would misidentify a cursed item because you roll a success but not a critical success, you simply can't identify it instead.
     prereq:
       level: 2
       skill: Occult/expert
@@ -1126,7 +1141,7 @@ pf2e_feats:
     - General
     assoc_skill: Arcana
     traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
+    shortdesc: You know basic facts off the top of your head. Choose a skill you're an expert in that has the Recall Knowledge action and for which you have the Assurance feat. You can use the Recall Knowledge action with that skill as a free action once per round. If you do, you must use Assurance on the skill check.%r%r**Special** You can select this feat multiple times, choosing a different skill each time. You can use Automatic Knowledge with any skills you have chosen, but you can still use Automatic Knowledge only once per round.
     prereq:
       level: 2
       skill: Arcana/expert
@@ -1138,7 +1153,7 @@ pf2e_feats:
     - General
     assoc_skill: Crafting
     traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
+    shortdesc: You know basic facts off the top of your head. Choose a skill you're an expert in that has the Recall Knowledge action and for which you have the Assurance feat. You can use the Recall Knowledge action with that skill as a free action once per round. If you do, you must use Assurance on the skill check.%r%r**Special** You can select this feat multiple times, choosing a different skill each time. You can use Automatic Knowledge with any skills you have chosen, but you can still use Automatic Knowledge only once per round.
     prereq:
       level: 2
       skill: Crafting/expert
@@ -1150,7 +1165,7 @@ pf2e_feats:
     - General
     assoc_skill: Medicine
     traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
+    shortdesc: You know basic facts off the top of your head. Choose a skill you're an expert in that has the Recall Knowledge action and for which you have the Assurance feat. You can use the Recall Knowledge action with that skill as a free action once per round. If you do, you must use Assurance on the skill check.%r%r**Special** You can select this feat multiple times, choosing a different skill each time. You can use Automatic Knowledge with any skills you have chosen, but you can still use Automatic Knowledge only once per round.
     prereq:
       level: 2
       skill: Medicine/expert
@@ -1162,7 +1177,7 @@ pf2e_feats:
     - General
     assoc_skill: Nature
     traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
+    shortdesc: You know basic facts off the top of your head. Choose a skill you're an expert in that has the Recall Knowledge action and for which you have the Assurance feat. You can use the Recall Knowledge action with that skill as a free action once per round. If you do, you must use Assurance on the skill check.%r%r**Special** You can select this feat multiple times, choosing a different skill each time. You can use Automatic Knowledge with any skills you have chosen, but you can still use Automatic Knowledge only once per round.
     prereq:
       level: 2
       skill: Nature/expert
@@ -1174,7 +1189,7 @@ pf2e_feats:
     - General
     assoc_skill: Occultism
     traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
+    shortdesc: You know basic facts off the top of your head. Choose a skill you're an expert in that has the Recall Knowledge action and for which you have the Assurance feat. You can use the Recall Knowledge action with that skill as a free action once per round. If you do, you must use Assurance on the skill check.%r%r**Special** You can select this feat multiple times, choosing a different skill each time. You can use Automatic Knowledge with any skills you have chosen, but you can still use Automatic Knowledge only once per round.
     prereq:
       level: 2
       skill: Occultism/expert
@@ -1186,7 +1201,7 @@ pf2e_feats:
     - General
     assoc_skill: Religion
     traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
+    shortdesc: You know basic facts off the top of your head. Choose a skill you're an expert in that has the Recall Knowledge action and for which you have the Assurance feat. You can use the Recall Knowledge action with that skill as a free action once per round. If you do, you must use Assurance on the skill check.%r%r**Special** You can select this feat multiple times, choosing a different skill each time. You can use Automatic Knowledge with any skills you have chosen, but you can still use Automatic Knowledge only once per round.
     prereq:
       level: 2
       skill: Religion/expert
@@ -1198,7 +1213,7 @@ pf2e_feats:
     - General
     assoc_skill: Society
     traits: []
-    shortdesc: Recall Knowledge as a free action once per round.
+    shortdesc: You know basic facts off the top of your head. Choose a skill you're an expert in that has the Recall Knowledge action and for which you have the Assurance feat. You can use the Recall Knowledge action with that skill as a free action once per round. If you do, you must use Assurance on the skill check.%r%r**Special** You can select this feat multiple times, choosing a different skill each time. You can use Automatic Knowledge with any skills you have chosen, but you can still use Automatic Knowledge only once per round.
     prereq:
       level: 2
       skill: Society/expert
@@ -1212,7 +1227,7 @@ pf2e_feats:
     traits:
     - general
     - skill
-    shortdesc: Make a battle plan and roll Warfare Lore for initiative.
+    shortdesc: You are constantly drawing up plans and battle scenarios, assembling strategies and gathered intelligence for later use. When you scout an enemy's position or receive a detailed report from an ally who scouted the enemy's position, if you have a clear indication of the number, position, and identities of your potential foes, you can spend 1 minute to come up with a battle plan that takes such potential factors into account and reduces the role luck plays in the equation. Roll a Warfare Lore check. As long as the information was accurate and remains accurate when you roll initiative against those enemies, you can use the Warfare Lore result you previously rolled for your initiative roll; if you do, this is a fortune effect.
     prereq:
       level: 2
       skill: Warfare Lore/expert
@@ -1223,7 +1238,7 @@ pf2e_feats:
     assoc_skill: Nature
     traits:
     - downtime
-    shortdesc: An animal becomes permanently helpful to you.
+    shortdesc: You forge strong connections with animals. You can spend 7 days of downtime regularly interacting with a normal animal (not a companion or other special animal) that is friendly or helpful to you. After this duration, attempt a DC 20 Nature check. If successful, you bond with the animal. The animal is permanently helpful to you, unless you do something egregious to break your bond. A helpful animal is easier to direct, as described under Command an Animal.%r%rBonding with a new animal ends any previous bond you had. You can't have both a bonded animal and an animal companion (though you can have both a bonded animal and a familiar).
     prereq:
       level: 2
       skill: Nature/expert
@@ -1233,7 +1248,7 @@ pf2e_feats:
     - Skill
     assoc_skill: Deception
     traits: []
-    shortdesc: Reduce the bonuses against your repeated lies.
+    shortdesc: Even when caught in falsehoods, you pile lie upon lie. Reduce the circumstance bonus a target gains for your previous attempts to Create a Diversion or Lie to it from +4 to +2. If you're a master in Deception, reduce the bonus to +1, and if you're legendary, your targets don't get these bonuses at all.
     prereq:
       level: 2
       skill: Deception/expert  
@@ -1243,7 +1258,7 @@ pf2e_feats:
     - Skill
     assoc_skill: Society
     traits: []
-    shortdesc: Leverage your connections for favors and meetings.
+    shortdesc: You have social connections you can leverage to trade favors or meet important people. When you're in an area with connections (typically a settlement where you've spent downtime building connections, or possibly another area in the same nation), you can attempt a Society check to arrange a meeting with an important political figure or ask for a favor in exchange for a later favor of your contact's choice. The GM decides the DC based on the difficulty of the favor and the figure's prominence.
     prereq:
       level: 2
       skill: Society/expert
@@ -1256,7 +1271,7 @@ pf2e_feats:
     - General
     assoc_skill: Medicine
     traits: []
-    shortdesc: Treat Wounds on a patient more often.
+    shortdesc: You zealously monitor a patient's progress to administer treatment faster. When you Treat Wounds, your patient becomes immune for only 10 minutes instead of 1 hour. This applies only to your Treat Wounds activities, not any other the patient receives.
     prereq:
       level: 2
       skill: Medicine/expert
@@ -1266,7 +1281,7 @@ pf2e_feats:
     - General
     assoc_skill: Society
     traits: []
-    shortdesc: Leverage your underworld connections for favors from criminals.
+    shortdesc: You have dealings with a variety of unsavory characters, which you can leverage to trade favors or meet powerful people. When you're in an area where you have connections (typically a settlement where you've spent downtime building connections or possibly another area in the same nation), you can attempt a Society check to arrange a meeting with an important criminal, such as a thieves' guild leader, or ask for a favor in exchange for a later favor of your contact's choice. The GM decides the DC based on the difficulty of the favor and the figure's prominence.
     prereq:
       level: 2
       skill: Society/expert
@@ -1279,7 +1294,7 @@ pf2e_feats:
     - Skill
     assoc_skill: Deception
     traits: []
-    shortdesc: Gather Information without revealing your motive.
+    shortdesc: You are subtle in your efforts to learn the things you need to know. When Gathering Information, you can hide the true subject of your inquiry among other topics of little interest to you without increasing the difficulty of the check or taking more time to Gather Information. Anyone trying to Gather Information to determine if someone else was asking around about the topic in question must exceed your Deception DC or the normal DC to Gather Information about your inquiries, whichever is higher, or else they don't learn of your efforts.
     prereq:
       level: 2
       orskill: 
@@ -1291,7 +1306,7 @@ pf2e_feats:
     - General
     assoc_skill: Diplomacy
     traits: []
-    shortdesc: Gather Information without revealing your motive.
+    shortdesc: You are subtle in your efforts to learn the things you need to know. When Gathering Information, you can hide the true subject of your inquiry among other topics of little interest to you without increasing the difficulty of the check or taking more time to Gather Information. Anyone trying to Gather Information to determine if someone else was asking around about the topic in question must exceed your Deception DC or the normal DC to Gather Information about your inquiries, whichever is higher, or else they don't learn of your efforts.
     prereq:
       level: 2
       orskill: 
@@ -1303,7 +1318,7 @@ pf2e_feats:
     - General
     assoc_skill: Performance
     traits: []
-    shortdesc: Create a Diversion for an ally.
+    shortdesc: Your performances are especially distracting, allowing your allies to Sneak away with ease. When you Aid an ally who is trying to Create a Diversion, instead of the usual effects of Aid, you can roll a Performance check and use that result to determine the outcome of the diversion, instead of the ally rolling a Deception check.
     prereq:
       level: 2
       skill: Performance/expert
@@ -1313,7 +1328,7 @@ pf2e_feats:
     - General
     assoc_skill: Religion
     traits: []
-    shortdesc: +2 to Request something of or Coerce members of your own faith.
+    shortdesc: Your knowledge of the tenets of your faith gives you insight into the best ways to get others of your faith to help you or to follow your directions. When you Request something of or Coerce members of your own faith, you can attempt a Religion check instead of Diplomacy or Intimidation, and you gain a +2 circumstance bonus to the check. On a critically failed attempt to make a Request, the target's attitude toward you doesn't worsen.
     prereq:
       level: 2
       skill: Religion/expert  
@@ -1323,7 +1338,7 @@ pf2e_feats:
     - General
     assoc_skill: Diplomacy
     traits: []
-    shortdesc: Make an Impression on a target you've just met.
+    shortdesc: First impressions are your strong suit. When you meet someone in a casual or social situation, you can immediately attempt a Diplomacy check to Make an Impression on that creature rather than needing to converse for 1 minute. You take a –5 penalty to the check. If you fail or critically fail, you can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result.
     prereq:
       level: 2
       skill: diplomacy/expert
@@ -1333,7 +1348,7 @@ pf2e_feats:
     - General
     assoc_skill: Intimidation
     traits: []
-    shortdesc: Gain bonus to physically Demoralize a target.
+    shortdesc: In situations where you can physically menace the target when you Coerce or Demoralize, you gain a +1 circumstance bonus to your Intimidation check and you ignore the penalty for not sharing a language. If your Strength score is 20 or higher and you are a master in Intimidation, this bonus increases to +2.
     prereq:
       level: 2
       skill: Intimidation/expert
@@ -1345,7 +1360,7 @@ pf2e_feats:
     - General
     assoc_skill: Intimidation
     traits: []
-    shortdesc: Coerce a target into helping you longer.
+    shortdesc: When you successfully Coerce someone, the maximum time they comply increases to a week, still determined by the GM. If you're legendary, the maximum increases to a month.
     prereq:
       level: 2
       skill: Intimidation/expert
@@ -1355,7 +1370,7 @@ pf2e_feats:
     - General
     assoc_skill: Athletics
     traits: []
-    shortdesc: Make Climbing safer for allies who Follow the Expert.
+    shortdesc: When climbing, you can prepare routes for others to follow, and you can pull your allies up to avoid disaster. When your allies attempt to Climb a route you set using the Follow the Expert exploration activity, if any of them critically fail their checks to Climb, you can attempt an Athletics check against the same DC. If you succeed, your ally fails instead of critically failing. If you also critically fail, you both experience the consequences of the critical failure.
     prereq:
       level: 2
       skill: Athletics/expert
@@ -1365,7 +1380,7 @@ pf2e_feats:
     - General
     assoc_skill: Crafting
     traits: []
-    shortdesc: Craft magic items.
+    shortdesc: You can Craft magic items, though some have other requirements. When you select this feat, you gain formulas for four common magic items of 2nd level or lower.
     prereq:
       level: 2
       skill: Crafting/expert
@@ -1375,7 +1390,7 @@ pf2e_feats:
     - General
     assoc_skill: Arcana
     traits: []
-    shortdesc: Learn spells quickly and at a reduced cost.
+    shortdesc: Learning spells comes easily to you. If you're an expert in a tradition's associated skill, you take 10 minutes per spell level to learn a spell of that tradition, rather than 1 hour per spell level. If you fail to learn the spell, you can try again after 1 week or after you gain a level, whichever comes first. If you're a master in the tradition's associated skill, learning a spell takes 5 minutes per spell level, and if you're legendary, it takes 1 minute per spell level. You can use downtime to learn and inscribe new spells. This works as if you were using Earn Income with the tradition's associated skill, but instead of gaining money, you choose a spell available to you to learn and gain a discount on learning it, learning it for free if your earned income equals or exceeds its cost.
     prereq:
       level: 2
       skill: Arcana/expert
@@ -1385,7 +1400,7 @@ pf2e_feats:
     - General
     assoc_skill: Religion
     traits: []
-    shortdesc: Learn spells quickly and at a reduced cost.
+    shortdesc: Learning spells comes easily to you. If you're an expert in a tradition's associated skill, you take 10 minutes per spell level to learn a spell of that tradition, rather than 1 hour per spell level. If you fail to learn the spell, you can try again after 1 week or after you gain a level, whichever comes first. If you're a master in the tradition's associated skill, learning a spell takes 5 minutes per spell level, and if you're legendary, it takes 1 minute per spell level. You can use downtime to learn and inscribe new spells. This works as if you were using Earn Income with the tradition's associated skill, but instead of gaining money, you choose a spell available to you to learn and gain a discount on learning it, learning it for free if your earned income equals or exceeds its cost.
     prereq:
       level: 2
       skill: Religion/expert
@@ -1395,7 +1410,7 @@ pf2e_feats:
     - General
     assoc_skill: Occultism
     traits: []
-    shortdesc: Learn spells quickly and at a reduced cost.
+    shortdesc: Learning spells comes easily to you. If you're an expert in a tradition's associated skill, you take 10 minutes per spell level to learn a spell of that tradition, rather than 1 hour per spell level. If you fail to learn the spell, you can try again after 1 week or after you gain a level, whichever comes first. If you're a master in the tradition's associated skill, learning a spell takes 5 minutes per spell level, and if you're legendary, it takes 1 minute per spell level. You can use downtime to learn and inscribe new spells. This works as if you were using Earn Income with the tradition's associated skill, but instead of gaining money, you choose a spell available to you to learn and gain a discount on learning it, learning it for free if your earned income equals or exceeds its cost.
     prereq:
       level: 2
       skill: Occultism/expert  
@@ -1405,7 +1420,7 @@ pf2e_feats:
     - General
     assoc_skill: Nature
     traits: []
-    shortdesc: Learn spells quickly and at a reduced cost.
+    shortdesc: Learning spells comes easily to you. If you're an expert in a tradition's associated skill, you take 10 minutes per spell level to learn a spell of that tradition, rather than 1 hour per spell level. If you fail to learn the spell, you can try again after 1 week or after you gain a level, whichever comes first. If you're a master in the tradition's associated skill, learning a spell takes 5 minutes per spell level, and if you're legendary, it takes 1 minute per spell level. You can use downtime to learn and inscribe new spells. This works as if you were using Earn Income with the tradition's associated skill, but instead of gaining money, you choose a spell available to you to learn and gain a discount on learning it, learning it for free if your earned income equals or exceeds its cost.
     prereq:
       level: 2
       skill: Nature/expert
@@ -1415,7 +1430,7 @@ pf2e_feats:
     - General
     assoc_skill: Acrobatics
     traits: []
-    shortdesc: Crawl at a faster rate.
+    shortdesc: You can Crawl incredibly swiftly—up to half your Speed, rather than 5 feet. If you're a master in Acrobatics, you can Crawl at full Speed, and if you're legendary, you aren't flat-footed while prone.
     prereq: 
       level: 2
       skill: Acrobatics/expert
@@ -1425,7 +1440,7 @@ pf2e_feats:
     - General
     assoc_skill: Athletics
     traits: []
-    shortdesc: Jump farther and higher.
+    shortdesc: When you Leap, you can jump 5 feet up with a vertical Leap, and you increase the distance you can jump horizontally by 5 feet.
     prereq:
       level: 2
       skill: Athletics/expert
@@ -1435,7 +1450,7 @@ pf2e_feats:
     - General
     assoc_skill: Society
     traits: []
-    shortdesc: Spend only 1 day to use Connections or Criminal Connections.
+    shortdesc: You know where to go, who to talk to, and how to make new connections, fast. Upon entering a new settlement, spending 1 day of downtime allows you to build enough connections to make use of the Connections or Underworld Connections feats. If you're legendary in Society, you can form the required connections within 1 hour of entering a new settlement.
     prereq:
       level: 2
       skill: Society/expert
@@ -1448,7 +1463,7 @@ pf2e_feats:
     - General
     assoc_skill: Deception
     traits: []
-    shortdesc: Set up a disguise in only half the time.
+    shortdesc: You can set up a disguise in half the usual time (generally 5 minutes). If you're a master, it takes one-tenth the usual time (usually 1 minute). If you're legendary, you can create a full disguise and Impersonate as a 3-action activity.
     prereq:
       level: 2
       skill: Deception/expert
@@ -1458,7 +1473,7 @@ pf2e_feats:
     - General
     assoc_skill: Stealth
     traits: []
-    shortdesc: Roll a single Stealth check when sneaking with allies.
+    shortdesc: You're skilled at moving with a group. When you are Avoiding Notice and your allies Follow the Expert, you and those allies can roll a single Stealth check, using the lowest modifier, instead of rolling separately. This doesn't apply for initiative rolls.
     prereq:
       level: 2
       skill: Stealth/expert
@@ -1468,7 +1483,7 @@ pf2e_feats:
     - General
     assoc_skill: Athletics
     traits: []
-    shortdesc: Pull yourself onto ledges quickly.
+    shortdesc: You easily pull yourself onto ledges. When you Grab an Edge, you can pull yourself onto that surface and stand. You can use Athletics instead of a Reflex save to Grab an Edge.
     prereq:
       level: 2
       skill: Athletics/expert
@@ -1478,7 +1493,7 @@ pf2e_feats:
     - General
     assoc_skill: Medicine
     traits: []
-    shortdesc: Greater benefits from Treat Disease and Treat Poison.
+    shortdesc: You learned folk medicine to help recover from diseases and poison, and using it diligently has made you especially resilient. When you Treat a Disease or a Poison, or someone else uses one of these actions on you, increase the circumstance bonus granted on a success to +4, and if the result of the patient's saving throw is a success, the patient gets a critical success.
     prereq:
       level: 2
       skill: Medicine/expert
@@ -1488,7 +1503,7 @@ pf2e_feats:
     - General
     assoc_skill: Stealth
     traits: []
-    shortdesc: Targets you’re following take a penalty to notice you.
+    shortdesc: You have learned special tricks that help you follow individuals without them noticing you. When you attempt a Stealth check to Avoid Notice while following a specific target, the target takes a –2 circumstance penalty to their Perception DC. If you have master proficiency in Stealth, the penalty is –3 or –4 if you're legendary. If you start an encounter with the target while shadowing them, the target takes this penalty to their initiative roll and to their Perception DC to determine if they notice you, as normal for Sneak.
     prereq:
       level: 2
       skill: Stealth/expert
@@ -1498,7 +1513,7 @@ pf2e_feats:
     - General
     assoc_skill: Intimidation
     traits: []
-    shortdesc: +1 to spell saves from a creature you've Demoralized.
+    shortdesc: The spells of those you have Demoralized are less effective on you. If you succeed in Demoralizing a creature, for the next 24 hours you gain a +1 circumstance bonus to saving throws against that creature's spells.
     prereq:
       level: 2
       skill: Intimidation/expert
@@ -1508,7 +1523,7 @@ pf2e_feats:
     - Skill
     assoc_skill: Society
     traits: []
-    shortdesc: Gather Information without drawing attention and gain a bonus to Recall Knowledge about that subject.
+    shortdesc: You're connected to groups that know what's going on in the streets, and you can get information out of them quickly. When you use Society to Gather Information in an area where you have a network (typically a settlement where you've spent at least a week or spent a day of downtime to build a network faster), you can contact a member of these groups to get information directly from them. This usually takes about an hour, and it doesn't draw as much attention as Gathering Information in public might. The check and information gained otherwise follow the normal rules for Gather Information.%r%rIn addition, if you have successfully consulted the underground network, you get a +1 circumstance bonus to the next check to Recall Knowledge you attempt about the subject you were Gathering Information on, or a +2 circumstance bonus if you're using Underworld Lore for the check. The GM might change the Lore skill related to the network depending on your location or the specifics of the network you're tapping into.
     prereq:
       level: 2
       skill: Society/expert
@@ -1520,7 +1535,7 @@ pf2e_feats:
     - General
     - Skill
     traits: []
-    shortdesc: Recall Knowledge about your Lore more effectively.
+    shortdesc: You never get information about your areas of expertise wrong. When you Recall Knowledge using any Lore subcategory in which you're trained, if you roll a critical failure, you get a failure instead. If you're a master in a Lore subcategory, on a critical success, you gain even more information or context than usual.
     prereq:
       level: 2
   Ward Medic:
@@ -1529,7 +1544,7 @@ pf2e_feats:
     - General
     assoc_skill: Medicine
     traits: []
-    shortdesc: Treat several patients at once.
+    shortdesc: You've studied in large medical wards, treating several patients at once and tending to all their needs. When you use Treat Disease or Treat Wounds, you can treat up to two targets. If you're a master in Medicine, you can treat up to four targets, and if you're legendary, you can treat up to eight targets.
     prereq:
       level: 2
       skill: Medicine/expert
@@ -1539,7 +1554,435 @@ pf2e_feats:
     - General
     assoc_skill: Thievery
     traits: []
-    shortdesc: +2 to AC or saves against devices or traps you trigger while disarming.
+    shortdesc: If you trigger a device or set off a trap while disarming it, you gain a +2 circumstance bonus to your AC or saving throw against the device or trap. This applies only to attacks or effects triggered by your failed attempt, not to any later ones, such as additional attacks from a complex trap.
     prereq:
       level: 2
       skill: Thievery/expert
+  Advanced First Aid:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Medicine
+    traits:
+    - healing
+    - manipulate
+    shortdesc: You use your medical training to ameliorate sickness or assuage fears. When you use Medicine to Administer First Aid, instead of Stabilizing a character or Stopping Bleeding, you can reduce an ally's frightened or sickened condition by 2, or remove either of those conditions entirely on a critical success. You can remove only one condition at a time. The DC for the Medicine check is usually the DC of the effect that caused the condition.
+    prereq:
+      level: 7
+      skill: Medicine/master
+  Aerobatics Mastery:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Acrobatics
+    traits: []
+    shortdesc: You move with grace in flight and can perform amazing aerial stunts. You gain a +2 circumstance bonus to Acrobatics checks to Maneuver in Flight and can combine two maneuvers into a single action, such as reversing direction while making a steep ascent or descent or hovering in gale-force winds. The DC of the Acrobatics check is equal to the DC of the most difficult maneuver + 5. If you're legendary in Acrobatics, you can combine three such maneuvers into a single action; the DC of the Acrobatics check is equal to the DC of the most difficult maneuver + 10. Regardless of the combination, these maneuvers rarely allow you to move farther than your fly Speed.
+    prereq:
+      level: 7
+      skill: Acrobatics/master
+  Battle Cry:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Intimidation
+    traits: []
+    shortdesc: When you roll initiative, you can yell a mighty battle cry and Demoralize an observed foe as a free action. If you're legendary in Intimidation, you can use a reaction to Demoralize your foe when you critically succeed at an attack roll.
+    prereq:
+      level: 7
+      skill: Intimidation/master
+  Biographical Eye:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits:
+    - secret
+    shortdesc: 
+    prereq:
+      level: 7
+      skill: Society/master
+  Bizarre Magic:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: You can draw upon strange variations in your spellcasting, whether or not you can cast occult spells. The DCs to Recognize Spells you cast and Identify Magic you use increase by 5.
+    prereq:
+      level: 7
+      skill: Occultism/master
+  Disturbing Knowledge:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits:
+    - emotion
+    - fear
+    - mental
+    shortdesc: You utter a litany of dreadful names, prophecies, and descriptions of realms beyond mortal comprehension, drawn from your study of forbidden tomes and scrolls. Even those who don't understand your language are unsettled by these dire secrets. Attempt an Occultism check and compare the result to the Will DC of an enemy within 30 feet, or to the Will DCs of any number of enemies within 30 feet if you are legendary in Occultism. Those creatures are temporarily immune for 24 hours.%r%r**Critical Success** The target becomes confused for 1 round and frightened 1.%r**Success** The target becomes frightened 1.%r**Failure** The target is unaffected.%r**Critical Failure** You get overly caught up in your own words and become frightened 1.
+    prereq:
+      level: 7
+      skill: Occultism/master
+  Doublespeak:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Deception
+    traits: []
+    shortdesc: You are skilled at saying one thing while meaning something different. You disguise your true meaning behind other words and phrases, relying on subtle emphasis and shared experience to convey meaning that only your allies understand. Any allies who have traveled alongside you for at least 1 full week automatically discern your meaning. Other observers must succeed at a Perception check against your Deception DC to realize you are passing a secret message, and they must critically succeed to understand the message itself.
+    prereq:
+      level: 7
+      skill: Deception/master
+  Foil Senses:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Stealth
+    traits: []
+    shortdesc: You are adept at foiling creatures' special senses and cautious enough to safeguard against them at all times. Whenever you use the Avoid Notice, Hide, or Sneak actions, you are always considered to be taking precautions against special senses (see the Detecting with Other Senses sidebar).
+    prereq:
+      level: 7
+      skill: Stealth/master
+  Impeccable Crafting:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Crafting
+    traits: []
+    shortdesc: You craft flawless creations with great efficiency. Whenever you roll a success at a Crafting check to make an item of the type you chose with Specialty Crafting, you get a critical success instead.
+    prereq:
+      level: 7
+      skill: Crafting/master
+      feat:
+      - Specialty Crafting
+  Influence Nature:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits:
+    - downtime
+    shortdesc: With patience and time, you can make bird calls, leave game trails, and ultimately influence the behavior of a certain type of animals in the region to favor and even aid you in the days to come. The GM determines the DC of any check required and the amount of time your work requires (usually at least a day or two of downtime). While you can't directly control how you've influenced nature, you can hope for certain effects, such as easier hunts or birds falling silent whenever danger is approaching. If you're legendary in Nature, you can elicit these same adjustments to animal behavior in the area by spending only 10 minutes.
+    prereq:
+      level: 7
+      skill: Nature/master
+  Kip Up:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Acrobatics
+    traits: []
+    shortdesc: You stand up. This movement doesn't trigger reactions.
+    prereq:
+      level: 7
+      skill: Acrobatics/master
+  Planar Survival:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: You can Subsist using Survival on different planes, even those without resources or natural phenomena you normally need. For instance, you can forage for food even if the plane lacks food that could normally sustain you. A success on your check to Subsist can also reduce the damage dealt by the plane, at the GM's discretion.
+    prereq:
+      level: 7
+      skill: Survival/master
+  Quick Climb:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: When Climbing, you move 5 more feet on a success and 10 more feet on a critical success, to a maximum of your Speed. If you're legendary in Athletics, you gain a climb Speed equal to your Speed.
+    prereq:
+      level: 7
+      skill: Athletics/master
+  Quick Recognition (Arcana):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Arcana
+    traits: []
+    shortdesc: You Recognize Spells swiftly. Once per round, you can Recognize a Spell using a skill in which you're a master as a free action.
+    prereq:
+      level: 7
+      skill: Arcana/master
+      feat:
+      - Recognize Spell
+  Quick Recognition (Nature):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Nature
+    traits: []
+    shortdesc: You Recognize Spells swiftly. Once per round, you can Recognize a Spell using a skill in which you're a master as a free action.
+    prereq:
+      level: 7
+      skill: Nature/master
+      feat:
+      - Recognize Spell
+  Quick Recognition (Occultism):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Occultism
+    traits: []
+    shortdesc: You Recognize Spells swiftly. Once per round, you can Recognize a Spell using a skill in which you're a master as a free action.
+    prereq:
+      level: 7
+      skill: Occultism/master
+      feat:
+      - Recognize Spell
+  Quick Recognition (Religion):
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: You Recognize Spells swiftly. Once per round, you can Recognize a Spell using a skill in which you're a master as a free action.
+    prereq:
+      level: 7
+      skill: Religion/master
+      feat:
+      - Recognize Spell
+  Quick Swim:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: You Swim 5 feet farther on a success and 10 feet farther on a critical success, to a maximum of your Speed. If you're legendary in Athletics, you gain a swim Speed equal to your Speed.
+    prereq:
+      level: 7
+      skill: Athletics/master
+  Quick Unlock:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Thievery
+    traits: []
+    shortdesc: You can Pick a Lock using 1 action instead of 2.
+    prereq:
+      level: 7
+      skill: Thievery/master
+  Rapid Affixture:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Crafting
+    traits: []
+    shortdesc: You take only 1 minute to Affix a Talisman. If you're legendary in Crafting, you can Affix a Talisman as a 3-action activity.
+    prereq:
+      level: 7
+      skill: Crafting/master
+  Shameless Request:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Diplomacy
+    traits: []
+    shortdesc: You can downplay the consequences or outrageousness of your requests using sheer brazenness and charm. When you Request something, you reduce any DC increases for making an outrageous request by 2, and if you roll a critical failure for your Request, you get a failure instead. While this means you can never cause your target to reduce their attitude toward you by making a Request, they eventually tire of requests, even though they still have a positive attitude toward you.
+    prereq:
+      level: 7
+      skill: Diplomacy/master
+  Slippery Secrets:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Deception
+    traits: []
+    shortdesc: You elude and evade attempts to uncover your true nature or intentions. When a spell or magical effect tries to read your mind, detect whether you are lying, or reveal your alignment, you can attempt a Deception check against the spell or effect's DC. If you succeed, the effect reveals nothing.
+    prereq:
+      level: 7
+      skill: Deception/master
+  Swift Sneak:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Stealth
+    traits: []
+    shortdesc: You can move your full Speed when you Sneak. You can use Swift Sneak while Burrowing, Climbing, Flying, or Swimming instead of Striding if you have the corresponding movement type.
+    prereq:
+      level: 7
+      skill: Stealth/master
+  Terrified Retreat:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Intimidation
+    traits: []
+    shortdesc: When you critically succeed at the Demoralize action, if the target's level is lower than yours, the target is fleeing for 1 round.
+    prereq:
+      level: 7
+      skill: Intimidation/master
+  Wall Jump:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: You can use your momentum from a jump to propel yourself off a wall. If you're adjacent to a wall at the end of a jump (whether performing a High Jump, Long Jump, or Leap), you don't fall as long as your next action is another jump. Furthermore, since your previous jump gives you momentum, you can use High Jump or Long Jump as a single action, but you don't get to Stride as part of the activity.%r%rYou can use Wall Jump only once in a turn, unless you're legendary in Athletics, in which case you can use Wall Jump as many times as you can use consecutive jump actions in that turn.
+    prereq:
+      level: 7
+      skill: Athletics/master
+  Water Sprint:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: Experience and training have taught you that water has just enough surface tension for a master sprinter to traverse the surface. When you Stride in a straight line, if you move at least half your Speed over ground, you can move any amount of the remaining distance across a level body of water. If you don't end your Stride on solid ground, you fall into the water.%r%rIf you're legendary in Athletics, as long as you start on solid ground, any part of your Stride can cross the water's surface, even if you aren't moving a straight line, though you still fall into the water if you don't end your movement on solid ground.
+    prereq:
+      level: 7
+      skill: Athletics/master
+  Cloud Jump:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Athletics
+    traits: []
+    shortdesc: You unparalleled athletic skill allows you to jump impossible distances. Triple the distance you Long Jump (so you could jump 60 feet on a successful DC 20 check). When you High Jump, use the calculation for a Long Jump but don't triple the distance.%r%rYou can jump a distance greater than your Speed by spending additional actions when you Long Jump or High Jump. For each additional action spent, add your Speed to the limit on how far you can Leap.
+    prereq:
+      level: 15
+      skill: Athletics/legendary
+  Craft Anything:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Crafting
+    traits: []
+    shortdesc: You can find ways to craft just about anything, despite restrictions. As long as you have the appropriate Crafting skill feat (such as Magical Crafting for magic items) and meet the item's level and proficiency requirement, you ignore just about any other requirement, such as being of a specific ancestry or providing spells. The only exceptions are requirements that add to the item's cost, including castings of spells that themselves have a cost, and requirements of special items such as the philosopher's stone that have exclusive means of access and Crafting. The GM decides whether you can ignore a requirement.
+    prereq:
+      level: 15
+      skill: Crafting/legendary
+  Divine Guidance:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Religion
+    traits: []
+    shortdesc: You're so immersed in divine scripture that you find meaning and guidance in your texts in any situation. Spend 10 minutes Deciphering Writing on religious scriptures of your deity or philosophy while thinking about a particular problem or conundrum you face, and then attempt a Religion check (DC determined by the GM). If you succeed, you unearth a relevant passage, parable, or aphorism that can help you move forward or change your thinking to help solve your conundrum. For example, the GM might provide you with a cryptic poem or hint that can guide you to the next step of solving your problem.
+    prereq:
+      level: 15
+      skill: Religion/legendary
+  Legendary Codebreaker:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: Your skill with languages and codes is so great that you can decipher information with little more than a quick read through a text. You can Decipher Writing using Society while reading at normal speed. If you slow down and spend the full amount of time that's ordinarily required and roll a success, you get a critical success; if you critically succeed while spending the normal amount of time, you gain a nearly word-for-word understanding of the document.
+    prereq:
+      level: 15
+      skill: Society/legendary
+  Legendary Guide:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: You know the wilderness so well that you can help your party travel through it with ease. When you are setting the path for your party through wilderness terrain, your party gains a +10-foot circumstance bonus to its Speed for the purpose of calculating the party's travel speed, your party's travel speed doesn't decrease in difficult terrain, and greater difficult terrain halves your party's travel speed instead of reducing it to a third. This doesn't increase your party's Speed during an encounter or allow your party to ignore difficult terrain during an encounter.
+    prereq:
+      level: 15
+      skill: Survival/legendary
+  Legendary Linguist:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Society
+    traits: []
+    shortdesc: You're so skilled with languages you can create a pidgin instantly. You can always talk to any creature that has a language—even a language you don't know —by creating a new pidgin language that uses simplified terms and conveys basic concepts. To do so, you must first understand at least what medium of communication the creature uses (speech, sign language, and so on).
+    prereq:
+      level: 15
+      skill: Society/legendary
+      feat:
+      - Multilingual
+  Legendary Medic:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Medicine
+    traits: []
+    shortdesc: You've discovered medical breakthroughs or techniques that achieve miraculous results. Once per day for each target, you can spend 1 hour treating that target and attempt a Medicine check to remove a disease or the blinded, deafened, doomed, or drained condition. Use the DC of the disease or of the spell or effect that created the condition. If the effect's source is an artifact, above 20th level, or similarly powerful, increase the DC by 10.
+    prereq:
+      level: 15
+      skill: Medicine/legendary
+  Legendary Negotiation:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Diplomacy
+    traits: []
+    shortdesc: You can negotiate incredibly quickly in adverse situations. You attempt to Make an Impression and then Request your opponent cease their current activity and engage in negotiations. You take a –5 penalty to your Diplomacy check. The GM sets the DC of the Request based on the circumstances—it's generally at least a very hard DC of the creature's level. Some creatures might simply refuse, and even those who agree to parley might ultimately find your arguments lacking and return to violence.
+    prereq:
+      level: 15
+      skill: Diplomacy/legendary
+  Legendary Performer:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Performance
+    traits: []
+    shortdesc: Your fame has spread throughout the lands. NPCs who succeed at a DC 10 Society check to Recall Knowledge have heard of you and usually have an attitude toward you one step better than normal, depending on your reputation and the NPC's disposition. For instance, if you're well-known for cruel and demanding behavior, creatures might be intimidated by you, rather than be friendly toward you.
+    prereq:
+      level: 15
+      skill: Performance/legendary
+      feat:
+      - Virtuosic Performer
+  Legendary Sneak:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Stealth
+    traits: []
+    shortdesc: You're always sneaking unless you choose to be seen, even when there's nowhere to hide. You can Hide and Sneak even without cover or being concealed. When you employ an exploration tactic other than Avoiding Notice, you also gain the benefits of Avoiding Notice unless you choose not to.
+    prereq:
+      level: 15
+      skill: Stealth/legendary
+      feat:
+      - Swift Sneak
+  Legendary Survivalist:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Survival
+    traits: []
+    shortdesc: You can survive indefinitely without food or water and can endure severe, extreme, and incredible cold and heat without taking damage from doing so.
+    prereq:
+      level: 15
+      skill: Survival/legendary
+  Legendary Thief:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Thievery
+    traits: []
+    shortdesc: Your ability to Steal defies belief. You can attempt to Steal something that is actively wielded or that would be extremely noticeable or time consuming to remove (like worn shoes or armor). You must do so slowly and carefully, spending at least 1 minute (and significantly longer for items that are normally time consuming to remove, like armor). Throughout this duration you must have some means of staying hidden, such as the cover of darkness or a bustling crowd. You take a –5 penalty to your Thievery check. Even if you succeed, if the item is extremely prominent—like a suit of full plate armor—onlookers will quickly notice it's gone after you steal it.
+    prereq:
+      level: 15
+      skill: Thievery/legendary
+      feat:
+      - Pickpocket
+  Scare to Death:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Intimidation
+    traits:
+    - emotion
+    - fear
+    - incapacitation
+    shortdesc: You can frighten foes so much, they might die. Attempt an Intimidation check against the Will DC of a living creature within 30 feet of you that you sense or observe and who can sense or observe you. If the target can't hear you or doesn't understand the language you are speaking, you take a –4 circumstance penalty. The creature is temporarily immune for 1 minute.%r%r**Critical Success** The target must attempt a Fortitude save against your Intimidation DC. On a critical failure, it dies. On any other result, it becomes frightened 2 and is fleeing for 1 round. The critical failure effect has the death trait.%r**Success** The target becomes frightened 2.%r**Failure** The target becomes frightened 1.%r**Critical Failure** The target is unaffected.
+    prereq:
+      level: 15
+      skill: Intimidation/legendary
+  Unified Theory:
+    feat_type: 
+    - Skill
+    - General
+    assoc_skill: Arcana
+    traits: []
+    shortdesc: You've started to make a meaningful connection about the common underpinnings of the four traditions of magic and magical essences, allowing you to understand them all through an arcane lens. Whenever you use a skill action or a skill feat that requires a Nature, Occultism, or Religion check, depending on the magic tradition, you can use Arcana instead. If you would normally take a penalty or have a higher DC for using Arcana on other magic (such as when using Identify Magic), you no longer do so.
+    prereq:
+      level: 15
+      skill: Arcana/legendary

--- a/game/config/pf2e_heritages.yml
+++ b/game/config/pf2e_heritages.yml
@@ -383,30 +383,6 @@ pf2e_heritage:
     skills: []
     traits: []
 # Human Heritages
-  Half-Oruch:
-    traits:
-    - oruch
-    - half-oruch
-    special:
-    - Low-Light Vision
-    action: []
-    attack: {}
-    defense: {}
-    feat: []
-    reaction: []
-    skills: []
-  Half-Sil:
-    traits:
-    - half-sil
-    - sildanyar
-    special:
-    - Low-Light Vision
-    action: []
-    attack: {}
-    defense: {}
-    feat: []
-    reaction: []
-    skills: []
   Skilled:
     skills:
     - open
@@ -632,6 +608,31 @@ pf2e_heritage:
     skills: []
     special: []
     traits: []
+# Limited Heritages
+  Ghaluch:
+    traits:
+    - oruch
+    - ghaluch
+    special:
+    - Low-Light Vision
+    action: []
+    attack: {}
+    defense: {}
+    feat: []
+    reaction: []
+    skills: []
+  Silyara:
+    traits:
+    - silyara
+    - sildanyar
+    special:
+    - Low-Light Vision
+    action: []
+    attack: {}
+    defense: {}
+    feat: []
+    reaction: []
+    skills: []
 # Versatile Heritages
   Aesa:
     rare: true

--- a/game/config/pf2e_languages.yml
+++ b/game/config/pf2e_languages.yml
@@ -1,41 +1,71 @@
-
 pf2e_languages:
   common:
-    Tradespeak: Descended from Veyshanti, the language of merchantry across the world.
-    Veyshanti: The language of the desert kingdoms and the nomad clans between.
-    Myrrish: The language of the kingdoms that form Myrddion.
-    Charneth: The language of Charn.
-    Skyhaldan: The language of Skyhaldborg, far to the north.
-    Khazdul: The language of the dwarven kingdoms.
-    Silya: The Sildanyari tongue as it is spoken by those outside of the Greatwoods.
-    Gnomish: The language of the feytouched gnomes.
-    Giant: The language of the giants and their kin.
-    Yrch: The language of goblins, oruch, and arvek.
-    Handspeech: A silent communication system, analogous to Tradespeak.
-    Draconic: The language of dragons, adopted by Makari, Dragonier, and many others.
-    Dranish: The language of the khanates of Dran.
-    Bludguni: A form of Yrch spoken most commonly in Bludgun.
-    Bassini: The language of the bassin, often used for clandestine communication.
-    Kaillin: The flowery language of the rat-like Kailli.
+    Kamin: Descended from Veyshanti and Kaminean, Kamin is the most prominent language in Ea. Vantyrian language.
+    # Aiglosian Languages
+    Myrrish: The language of the Myrrish kingdoms. Aiglosian language.
+    Charneth: The language of Charn, also known as the Eastern Empire. Aiglosian language.
+    # Draconic Languages
+    Am'sheri Draconic: The dialect of Draconic most common in Am'shere. Mutually intelligible with Kimitatui Draconic. Draconic language.
+    Kimitatui Draconic: The dialect of Draconic most common in Kimitatu. Mutually intelligible with Am'sheri Draconic. Draconic language.
+    # Elemental Languages
+    Dranish: The elemental-infused language of the Witchlands of Dran. Elemental language.
+    # Feytongues
+    Gnomish: The language of the gnomes, descended from Sylhart. Feytongue language.
+    Silya: The modern sildanyari language that is most widely spoken within and outside Periantha. Feytongue language.
+    Sylhart: The most common and most modern language spoken by fey creatures. Feytoungue language.
+    # Jhoch Languages
+    Bludgunni: A newer language, synthesized from Yrch, Jhokunn, and Goblin. Can be understood by Goblin and Yrch speakers with difficulty. Jhoch language.
+    Goblin: Developed from Yrch, Goblin is spoken primarily by goblins, arvek, and those who interact with them the most. Jhoch language.
+    Kaillin: The intricate spoken and nonverbal language of the rat-like kailli. Difficult to learn without a tail. Jhoch language.
+    Yrch: The most common language among oruch. Jhoch language.
+    # Khazadi Languages
+    Khazdul: The most common language among the khazadi. Khazadi language.
+    # Skyhaldan Languages
+    Skyhaldan: The language of the residents of Skyhaldborg. Skyhaldan language.
+    # Vantyrian Languages
+    Kaitoi: The language of the Kaitoi, the proud people of the Jade Islands. Vantyrian language.
+    Veyshanti: The group of dialects that belong to the One-Hundred and Four of Veyshan. Vantyrian language.
+    # Other Common Languages
+    Bassini: The language of the bassian, seemingly unrelated to any other language in Ea.
+    # Sign Languages
+    Promise Sign: The sign language of Bludgun.
+    Empyrean Sign: The sign language of Charn. Also found in the Heartlands.
+    Ithildin Sign: The sign language of Myrddion. Also found in the Heartlands.
+    Thalassic Sign: The sign language of Dran.
+    Sha Sign: The sign language of the Jade Islands and Veyshan.
+    Iocanthian Sign: The sign language of Khazad Duin.
+    Dragonsign: The sign language of Kimitatu.
+    Caeldra Sign: The sign language of Periantha.
+    Runish System: The sign language of Rune. Known officially within Rune as Hand and Nonverbal Discourse (HAND).
+    Sky Sign: The sign language of Skyhaldborg.
+    Tysmychan Sign: The sign language of Tysmycha.
   uncommon:
-    Sylvan: The language of fey creatures.
-    Terran: The language of elemental Earth.
-    Aquan: The language of elemental Water.
-    Auran: The language of elemental Air.
-    Ignan: The language of elemental Fire.
-    Necril: The language of undead, although not universally spoken.
-    Infernal: The language of the devils of the Iron Hells.
-    Celestial: The language of the heavenly hosts.
     Abyssal: The language of the demons of the Abyss.
-    Sildanyari: Spoken chiefly in the Greatwoods, this is the tongue that the lyranesi hold as pure.
-    Amsheri: A trade tongue used across the settlements and tribes of the Amshere jungles.
+    Aesyian: The language of the heavenly hosts.
+    Aklo: A language spoken by otherworldly creatures, which is difficult for mortals to learn.
+    Dalian: The language of the Dalians, who also live within Skyhaldborg. Skyhaldan language.
+    Infernal: The language of the devils of the Iron Hells.
+    Jhokunn: The language of the giants and their kin. Jhoch language.
+    Kaminean: The very rare precursor tongue to Kamin, spoken primarily within isolated Kaminean families and communities. Vantyrian language.
+    Kholo: The language of the gnolls, perhaps closest in relation to Kaillin. Jhoch language.
+    Petran: The language of elemental earth. Elemental language.
+    Pyric: The language of elemental fire. Elemental language.
+    Thalassic: The language of elemental water. Elemental language.
+    Sussuran: The language of elemental air. Elemental language.
+    Old Aiglosian: The precursor tongue of Myrrish and Charneth. Aiglosian language.
+    Ranix: The language of many intelligent undead and necromantic magic.
+    Saher: The language spoken by the nomadic peoples of the Great Sands of Veyshan. Vantyrian language.
+    Shadowtongue: Spoken primarily by creatures of the Void and some undead.
+    Sildanyari: The language of the sildanyari kingdom of Llyranost, as dictated by the Dawn Children. Feytongue language.
+    Zykan: The little-studied language of the peoples of the Wolfrot Marshes in Veyshan. Vantyrian language.
+  rare:
+    Elder Sylhart: The oldest of the feytongues, largely only spoken at the courts of the eldest fey. Feytongue language.
+    Middle Aiglosian: A fractured descendant language of Old Aiglosian that is poorly documented. Aiglosian language.
+    Mynsandraal: The first and oldest language of the sildanyari, fractured and the subject of great debate. Feytongue language.
+    Valgeag: Spoken by the reclusive and underground khazad-rukh, who are not inclined to teach the language to outsiders. Khazadi language.
   secret:
-    Vantyr: A dead language, spoken in the empire that fell before Tashraan's rise.
-    Aiglosian: The precursor tongue of Myrrish and Charneth, with several distinct periods.
-    Mynsandraal: The first language of the elves, which was spoken when they emerged from the fey realms.
-    Kulthian: A dead language used by the artificers of old Kulthos.
-    Druidic: A secret tongue only taught to Druids.
-#  regional: SPOILER
+    Druidic: A secret tongue only taught to druids. Feytongue language.
+#  regional: deprecated
 #    Skyhaldborg: Skyhaldan
 #    Dran: Dranish
 #    Alexandros: Myrrish

--- a/game/config/pf2e_spells_p-t.yml
+++ b/game/config/pf2e_spells_p-t.yml
@@ -3884,8 +3884,6 @@ pf2e_spells:
     heighten:
       7: You and the other targets can travel to any location within 1,000 miles.
       8: You and the other targets can travel to any location on the same planet. If you travel more than 1,000 miles, you arrive only 10 miles off target.
-      9: You and the other targets can travel to any location on another planet within the same solar system. Assuming you have accurate knowledge of the location's position and appearance, you arrive on the new planet 100 miles off target.
-      10: As the 9th-level version, but you and the other targets can travel to any planet within the same galaxy.
     base_level: 6
     range: 100 miles
     school: Conjuration


### PR DESCRIPTION
# Changelog

## pf2e_ancestry.yml
Renamed half-sil and half-oruch to silyara and ghaluch, then added them to the appropriate ancestries (aka, everything besides ciith, egalrin, and kailli).

## pf2e_deities.yml
- Unhid Animus.
- Some minor quality checks.

## pf2e_feat_ancestry.yml
- **All ancestry feats we plan on using are added.** Levels 1-20. Yes, really. YEAH BUDDY.
- They have their longdescs, too!

## pf2e_feat_general.yml
- Untrained Improvisation added!

## pf2e_feat_skill.yml
- **All skill feats 1-20 have been added.**
- They have longdescs! So now all that's needed is class feats.

## pf2e_heritages.yml
- Renamed half-sil and half-oruch heritages to silyara and ghaluch (to reflect pf2e_ancestry.yml).

## pf2e_languages.yml
- Final list of learnable languages, complete with descs.

## pf2e_spells_p-t.yml
- Tweaked Teleport so it can no longer do interplanetary travel. :')